### PR TITLE
BACKLOG-22223: Switch to auto-deploy for configuration

### DIFF
--- a/src/main/java/org/jahia/modules/richtext/configuration/RichTextConfiguration.java
+++ b/src/main/java/org/jahia/modules/richtext/configuration/RichTextConfiguration.java
@@ -1,6 +1,5 @@
 package org.jahia.modules.richtext.configuration;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jahia.api.settings.SettingsBean;
 import org.jahia.modules.richtext.RichTextConfigurationInterface;
@@ -17,15 +16,6 @@ import org.owasp.html.PolicyFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Writer;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -37,18 +27,13 @@ import java.util.stream.Collectors;
 }, immediate = true)
 public class RichTextConfiguration implements RichTextConfigurationInterface, ManagedServiceFactory {
 
-    private static Logger logger = LoggerFactory.getLogger(RichTextConfiguration.class);
-    private static String CONFIG_FILE_NAME_BASE = "org.jahia.modules.richtext.config-";
-    private static String DEFAULT_CONFIG_FILE_NAME = CONFIG_FILE_NAME_BASE + DEFAULT_POLICY_KEY + ".yml";
+    private static final Logger logger = LoggerFactory.getLogger(RichTextConfiguration.class);
+    private static final String CONFIG_FILE_NAME_BASE = "org.jahia.modules.richtext.config-";
     private Map<String, JSONObject> configs = new HashMap<>();
     private Map<String, String> siteKeyToPid = new HashMap<>();
-    private BundleContext context;
-    private SettingsBean settingsBean = org.jahia.settings.SettingsBean.getInstance();
 
     @Activate
     public void activate(BundleContext context) {
-        this.context = context;
-        deployDefaultConfig();
         logger.info("Activate RichTextConfiguration service");
     }
 
@@ -170,25 +155,6 @@ public class RichTextConfiguration implements RichTextConfigurationInterface, Ma
                 }
             } else {
                 target.put(key, source.get(key));
-            }
-        }
-    }
-
-    private void deployDefaultConfig() {
-        URL url = context.getBundle().getResource("META-INF/configuration-default/" + DEFAULT_CONFIG_FILE_NAME);
-        if (url != null) {
-            Path path = Paths.get(settingsBean.getJahiaVarDiskPath(), "karaf", "etc", DEFAULT_CONFIG_FILE_NAME);
-            if (!Files.exists(path)) {
-                try (InputStream input = url.openStream()) {
-                    List<String> lines = IOUtils.readLines(input, StandardCharsets.UTF_8);
-                    lines.add(0, "# This is default configuration provided by Jahia");
-                    try (Writer w = new FileWriter(path.toFile())) {
-                        IOUtils.writeLines(lines, null, w);
-                    }
-                    logger.info("Copied default richtext configuration to {}", path);
-                } catch (IOException e) {
-                    logger.error("Unable to copy richtext configuration", e);
-                }
             }
         }
     }

--- a/src/main/resources/META-INF/configurations/org.jahia.modules.richtext.config-default.yml
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.richtext.config-default.yml
@@ -1,3 +1,4 @@
+# This is default configuration provided by Jahia
 htmlFiltering:
   htmlSanitizerDryRun: false
   protocols:


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22223

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Use built-in auto-deploy for default config https://academy.jahia.com/documentation/jahia/jahia-8/developer/module-development/creating-custom-configurations#embedding-module-configuration

- Move to `configurations` folder to use configuration auto-deploy.
  - This overrides existing default config already installed
- Remove related deploy config code