### PR TITLE
TECH-1416 Ensure compatibility with new guava and graphql migrations.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,16 +46,6 @@
         <export-package>
             org.jahia.modules.htmlfiltering
         </export-package>
-        <import-package>
-            graphql.annotations.annotationTypes;version="[6.5,99)",
-            javax.jcr;version="[2.0,3)",
-            org.jahia.modules.graphql.provider.dxm;version="[2.7,4)",
-            org.jahia.osgi,
-            org.jahia.services.content,
-            org.osgi.framework;version="[1.8,2)",
-            org.slf4j;version="[1.7,2)",
-            org.jahia.services
-        </import-package>
     </properties>
 
     <repositories>
@@ -107,6 +97,18 @@
                 <configuration>
                     <instructions>
                         <_dsannotations>*</_dsannotations>
+                        <Import-Package>
+                            ${jahia.plugin.projectPackageImport},
+                            graphql.annotations.annotationTypes;version="[6.5,99)",
+                            javax.jcr;version="[2.0,3)",
+                            org.jahia.modules.graphql.provider.dxm;version="[2.19,4)",
+                            org.jahia.osgi,
+                            org.jahia.services.content,
+                            org.osgi.framework;version="[1.8,2)",
+                            org.slf4j;version="[1.7,2)",
+                            org.jahia.services,
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/TECH-1416

## Description

Try to fix compatibility between jahia 8.1.5 and 8.2 allowing embedding guava and a version range for imported packages of graphql 

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
