### PR TITLE
BACKLOG-22232: Fixing incorrect scm property in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,9 +34,10 @@
     <description>This modules provides configuration for HTML filtering.</description>
 
     <scm>
-        <connection>scm:git@github.com:Jahia/html-filtering.git</connection>
-        <developerConnection>scm:git@github.com:Jahia/html-filtering.git</developerConnection>
+        <connection>scm:git:git@github.com:Jahia/html-filtering.git</connection>
+        <developerConnection>scm:git:git@github.com:Jahia/html-filtering.git</developerConnection>
         <url>https://github.com/Jahia/html-filtering</url>
+        <tag>HEAD</tag>        
     </scm>
 
     <properties>


### PR DESCRIPTION
This should fix the following error:

```
Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3-jahia1:prepare (default-cli) on project html-filtering: The provider given in the SCM URL could not be found: No such provider: 'git@github.com'. -> [Help 1]
```