### PR TITLE
ci: update nightly to run on different jahia versions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,6 +11,13 @@ jobs:
     runs-on: self-hosted
     strategy:
       fail-fast: false
+      matrix:
+          env:
+            - jahia-image: jahia/jahia-ee-dev:8-SNAPSHOT
+              provisioning: provisioning-manifest-snapshot.yml
+            - jahia-image: jahia/jahia-ee:8.1.5.0
+              provisioning: provisioning-manifest-snapshot-jahia-8.1.5.0.yml
+
     timeout-minutes: 120
     steps:
       - uses: jahia/jahia-modules-action/helper@v2
@@ -24,9 +31,9 @@ jobs:
       - uses: jahia/jahia-modules-action/integration-tests@v2
         with:
           module_id: jcontent
-          jahia_image: jahia/jahia-ee-dev:8-SNAPSHOT
+          jahia_image: ${{ matrix.env.jahia-image }}
           testrail_project: HTML Filtering Module
-          tests_manifest: provisioning-manifest-snapshot.yml
+          tests_manifest:  ${{ matrix.env.provisioning }}
           should_use_build_artifacts: false
           should_skip_artifacts: true
           should_skip_notifications: false

--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -64,7 +64,7 @@ jobs:
           module_id: html-filtering
           testrail_project: HTML Filtering Module
           tests_manifest: provisioning-manifest-build.yml
-          jahia_image: jahia/jahia-ee-dev:8-SNAPSHOT
+          jahia_image: jahia/jahia-ee:8
           should_use_build_artifacts: true
           github_artifact_name: html-filtering-artifacts-${{ github.run_number }}
           bastion_ssh_private_key: ${{ secrets.BASTION_SSH_PRIVATE_KEY_JAHIACI }}

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -22,7 +22,6 @@ jobs:
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-          nexus_enterprise_releases_url: ${{ secrets.NEXUS_ENTERPRISE_RELEASES_URL }}
 
   build:
     name: Build Module
@@ -47,7 +46,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     container:
-      image: cyclonedx/cyclonedx-cli:0.24.2   
+      image: cyclonedx/cyclonedx-cli:0.24.2
     steps:
       - uses: jahia/jahia-modules-action/sbom-processing@v2
         with:
@@ -82,7 +81,7 @@ jobs:
           module_id: html-filtering
           testrail_project: HTML Filtering Module
           tests_manifest: provisioning-manifest-build.yml
-          jahia_image: jahia/jahia-ee-dev:8-SNAPSHOT
+          jahia_image: jahia/jahia-ee:8
           should_use_build_artifacts: true
           github_artifact_name: html-filtering-artifacts-${{ github.run_number }}
           bastion_ssh_private_key: ${{ secrets.BASTION_SSH_PRIVATE_KEY_JAHIACI }}

--- a/tests/provisioning-manifest-snapshot-jahia-8.1.5.0.yml
+++ b/tests/provisioning-manifest-snapshot-jahia-8.1.5.0.yml
@@ -1,0 +1,37 @@
+- addMavenRepository: 'https://store.jahia.com/nexus/content/repositories/jahia-public-app-store@id=JahiaStore'
+- addMavenRepository: 'https://devtools.jahia.com/nexus/content/groups/public/@snapshots@noreleases@id=JahiaSnapshot'
+
+# This modules were added during the switch from using jahia-discovery to jahia-ee
+- installBundle:
+  - 'mvn:org.jahia.modules/legacy-default-components'
+  - 'mvn:org.jahia.modules/press'
+  - 'mvn:org.jahia.modules/person'
+  - 'mvn:org.jahia.modules/news'
+  - 'mvn:org.jahia.modules/font-awesome'
+  - 'mvn:org.jahia.modules/calendar'
+  - 'mvn:org.jahia.modules/bootstrap3-core'
+  - 'mvn:org.jahia.modules/bootstrap3-components'
+  - 'mvn:org.jahia.modules/location'
+  - 'mvn:org.jahia.modules/topstories'
+  - 'mvn:org.jahia.modules/rating/3.2.0'
+  - 'mvn:org.jahia.modules/event/3.1.0'
+  - 'mvn:org.jahia.modules/bookmarks'
+  - 'mvn:org.jahia.modules/dx-base-demo-core'
+  - 'mvn:org.jahia.modules/dx-base-demo-templates/3.4.0'
+  - 'mvn:org.jahia.modules/dx-base-demo-components/2.4.0'
+  - 'mvn:org.jahia.modules/skins'
+  - 'mvn:org.jahia.modules/default-skins'
+  - 'mvn:org.jahia.modules/grid'
+  - 'mvn:org.jahia.modules/tabularList/8.1.0'
+  - 'mvn:org.jahia.modules/graphql-dxm-provider/2.22.0'
+  autoStart: true
+  uninstallPreviousVersion: true
+
+- import: "jar:mvn:org.jahia.modules/digitall/2.3.0/zip/import!/users.zip"
+- importSite: "jar:mvn:org.jahia.modules/digitall/2.3.0/zip/import!/Digitall.zip"
+
+- installBundle:
+    - 'mvn:org.jahia.modules/html-filtering'
+  autoStart: true
+  uninstallPreviousVersion: true
+- karafCommand: "bundle:list"


### PR DESCRIPTION
Make nightly run on jahia
- 8.1.5.0 (oldest supported version)
- latest 8-SNAPSHOT build (earlier supported version)
