### PR TITLE
feat: offer per-site, default and fallback configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,11 @@
 # HTML Filtering Configuration
 
-## How it works
+HTML filtering in Jahia uses a multi-level configuration resolution strategy to determine which rules to apply for a site:
 
-There is a default configuration provided by Jahia `org.jahia.modules.htmlfiltering.config-default.yaml` which will be applied as soon as html filtering is enable on a site.
-All site specific configuration will be used in union with the
-default. That is default configuration is applied first and then site specific configuration. You can use site specific configuration to
-add allowed elements and attributes, disallow elements or attributes on allowed elements or protocols.
+1. **Site-specific configuration**: `org.jahia.modules.htmlfiltering-<site key>.yml` found in any OSGi bundle
+2. **Default configuration**: `org.jahia.modules.htmlfiltering.default.yml` found in any OSGi bundle
+3. **Fallback configuration**: `org.jahia.modules.htmlfiltering.fallback.yml` provided by the *HTML Filtering* bundle
 
-1. Create a configuration file in yml format with your site key
-    * `org.jahia.modules.htmlfiltering.config-yourSiteKey.yml`
-2. Add configuration. Note that disallow trumps all allow configurations.
-   Which means you can have a somewhat permissive default and restrict as you see fit on per-site basis.
+The system tries to find a policy in the order listed above. If a site-specific configuration exists, it will be used. If not, the default configuration applies. If neither exists, the system falls back to the built-in configuration.
 
-```
-htmlFiltering:
-  protocols:
-    - http
-    - https
-  attributes:
-    - name: class
-      pattern: "(myclass1|myclass2)"
-      elements: a, p, i
-    - name: dir
-    - name: id
-      pattern: HTML_ID
-    ...
-  elements:
-    - name: h1, h2, ...
-  disallow:
-    protocols:
-      ...
-    attributes:
-      ...
-    elements:
-      ...
-```
-3. Deploy configuration on Jahia
-4. Enable html filtering on you site
-5. Edit a RichText component to have the content filtered
-
-## Todo
-
-1. List default patterns
-
+**Note**: The fallback configuration should not be modified as module updates would replace it.

--- a/src/main/java/org/jahia/modules/htmlfiltering/RegistryService.java
+++ b/src/main/java/org/jahia/modules/htmlfiltering/RegistryService.java
@@ -15,14 +15,32 @@
  */
 package org.jahia.modules.htmlfiltering;
 
+/**
+ * The RegistryService interface provides a mechanism to manage and retrieve
+ * HTML filtering policies for specific sites and workspaces.
+ * <p>
+ * This service allows retrieving a {@link Policy} for a specific site and workspace,
+ * enabling tailored HTML content filtering and validation based on the given context.
+ */
 public interface RegistryService {
+
+
     /**
-     * Get the policy for the given site and workspace.
-     * If the workspace does not exist for the given site, the default "live" workspace is used.
+     * Retrieves the HTML filtering policy for the specified site and workspace.
+     * <p>
+     * Policy resolution strategy (by priority):
+     * <ol>
+     *   <li>Site-specific configuration: <code>org.jahia.modules.htmlfiltering-&lt;site key&gt;.yml</code> found in any OSGi bundle</li>
+     *   <li>Default configuration: <code>org.jahia.modules.htmlfiltering.default.yml</code> found in any OSGi bundle, that can be used to configure multiple sites with the same configuration if they don't have a site-specific configuration</li>
+     *   <li>Fallback configuration: <code>org.jahia.modules.htmlfiltering.fallback.yml</code> provided by the <i>HTML Filtering</i> bundle</li>
+     * </ol>
+     * <p>
+     * <strong>Note:</strong> If the requested workspace does not exist for the given site, the default "live" workspace is used.
+     * The fallback configuration should not be overwritten as module updates would replace it.
      *
-     * @param siteKey       the site key
-     * @param workspaceName the workspace name
-     * @return the policy or null if no policy is found for the given site and workspace
+     * @param siteKey       the unique identifier for the site
+     * @param workspaceName the name of the workspace
+     * @return the policy applicable to the given site and workspace, or <code>null</code> if no policy is found
      */
     Policy getPolicy(String siteKey, String workspaceName);
 }

--- a/src/main/java/org/jahia/modules/htmlfiltering/ValidationResult.java
+++ b/src/main/java/org/jahia/modules/htmlfiltering/ValidationResult.java
@@ -73,7 +73,7 @@ public interface ValidationResult {
          * Retrieves a mapping of HTML tags to their corresponding sets of rejected attributes.
          * Each entry in the map represents an HTML tag as the key and a set of attribute names
          * that were rejected during validation for that tag as the value.
-         * <p><b>Note:</b> if the same tag name has been rejected multiple times, the attributes will be merged</p>
+         * <p><strong>Note:</strong> if the same tag name has been rejected multiple times, the attributes will be merged</p>
          *
          * @return a map where the keys are the names of HTML tags (as strings) and the values
          * are sets of strings representing the rejected attribute names for each tag.

--- a/src/main/java/org/jahia/modules/htmlfiltering/impl/AbstractSitePolicyService.java
+++ b/src/main/java/org/jahia/modules/htmlfiltering/impl/AbstractSitePolicyService.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2002-2025 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.htmlfiltering.impl;
+
+import org.osgi.service.cm.ConfigurationException;
+import org.osgi.service.cm.ManagedService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Dictionary;
+import java.util.concurrent.atomic.AtomicReference;
+
+abstract class AbstractSitePolicyService implements ManagedService {
+
+    // Uses getClass() to ensure logs show the correct implementing class name.
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final AtomicReference<SitePolicy> sitePolicyReference = new AtomicReference<>();
+
+    SitePolicy getSitePolicy() {
+        return sitePolicyReference.get();
+    }
+
+    @Override
+    public void updated(Dictionary<String, ?> properties) throws ConfigurationException {
+        if (properties == null) {
+            sitePolicyReference.set(null);
+            logger.info("Resetting site policy");
+        } else {
+            logger.info("Updating site policy with props: {}", properties);
+            SitePolicy sitePolicy = SitePolicy.SitePolicyBuilder.build(properties);
+            sitePolicyReference.set(sitePolicy);
+        }
+    }
+}

--- a/src/main/java/org/jahia/modules/htmlfiltering/impl/DefaultSitePolicyServiceImpl.java
+++ b/src/main/java/org/jahia/modules/htmlfiltering/impl/DefaultSitePolicyServiceImpl.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2002-2025 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.htmlfiltering.impl;
+
+import org.osgi.service.cm.ManagedService;
+import org.osgi.service.component.annotations.Component;
+
+@Component(immediate = true, service = {ManagedService.class, AbstractSitePolicyService.class},
+        property = {
+                "service.pid=org.jahia.modules.htmlfiltering.default",
+                "service.description=HTML filtering default policy service to retrieve the default policy to use for a site that does not have a site-specific configuration",
+                "service.vendor=Jahia Solutions Group SA"
+        })
+public final class DefaultSitePolicyServiceImpl extends AbstractSitePolicyService {
+}

--- a/src/main/java/org/jahia/modules/htmlfiltering/impl/FallbackSitePolicyServiceImpl.java
+++ b/src/main/java/org/jahia/modules/htmlfiltering/impl/FallbackSitePolicyServiceImpl.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2002-2025 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.htmlfiltering.impl;
+
+import org.osgi.service.cm.ManagedService;
+import org.osgi.service.component.annotations.Component;
+
+@Component(immediate = true, service = {ManagedService.class, AbstractSitePolicyService.class},
+        property = {
+                "service.pid=org.jahia.modules.htmlfiltering.fallback",
+                "service.description=HTML filtering fallback policy service to retrieve the fallback policy",
+                "service.vendor=Jahia Solutions Group SA"
+        })
+public final class FallbackSitePolicyServiceImpl extends AbstractSitePolicyService {
+
+}

--- a/src/main/java/org/jahia/modules/htmlfiltering/impl/RegistryServiceImpl.java
+++ b/src/main/java/org/jahia/modules/htmlfiltering/impl/RegistryServiceImpl.java
@@ -15,26 +15,18 @@
  */
 package org.jahia.modules.htmlfiltering.impl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.dataformat.javaprop.JavaPropsMapper;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.jahia.api.Constants;
 import org.jahia.modules.htmlfiltering.Policy;
 import org.jahia.modules.htmlfiltering.RegistryService;
-import org.jahia.modules.htmlfiltering.configuration.SiteCfg;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedServiceFactory;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 @Component(immediate = true, service = {RegistryService.class, ManagedServiceFactory.class},
         property = {
@@ -46,33 +38,21 @@ public final class RegistryServiceImpl implements RegistryService, ManagedServic
 
     private static final Logger logger = LoggerFactory.getLogger(RegistryServiceImpl.class);
 
-    private final JavaPropsMapper javaPropsMapper = JavaPropsMapper.builder()
-            .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, true)
-            .configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false)
-            .build();
+    /**
+     * Maps site keys to their corresponding {@link SitePolicy} configurations.
+     */
+    private final Map<String, SitePolicy> policiesBySiteKey = Collections.synchronizedMap(new HashMap<>());
 
     /**
-     * Configuration PID for the default site policy
+     * Maps persistent identities (PIDs) to their corresponding site keys.
      */
-    private final AtomicReference<String> defaultPid = new AtomicReference<>();
+    private final Map<String, String> sitesByPid = Collections.synchronizedMap(new HashMap<>());
 
-    /**
-     * A thread-safe map that associates persistent identities (PIDs) with {@link SitePolicy} instances.
-     * <p>
-     * This map is used to store and manage the configuration policies for specific site configurations
-     * in a synchronized manner. Each PID corresponds to a unique site configuration whose edit and live
-     * workspace policies are encapsulated by the {@link SitePolicy} class.
-     * <p>
-     * The map ensures thread-safe access and modifications by using a synchronized wrapper around
-     * a {@code HashMap}.
-     */
-    private final Map<String, SitePolicy> policyByPid = Collections.synchronizedMap(new HashMap<>());
+    @Reference(target = "(service.pid=org.jahia.modules.htmlfiltering.default)")
+    private AbstractSitePolicyService defaultSitePolicyService;
 
-    /**
-     * A map that associates a site key with its corresponding PID (persistent identity).
-     * This is used for managing and referencing the configurations associated with each site in the system.
-     */
-    private final Map<String, String> pidBySite = new HashMap<>();
+    @Reference(target = "(service.pid=org.jahia.modules.htmlfiltering.fallback)")
+    private AbstractSitePolicyService fallbackSitePolicyService;
 
     @Override
     public String getName() {
@@ -81,103 +61,55 @@ public final class RegistryServiceImpl implements RegistryService, ManagedServic
 
     @Override
     public void updated(String pid, Dictionary<String, ?> properties) throws ConfigurationException {
-        logger.debug("Updating configuration for pid {}", pid);
-
         // extracting the site key from the configuration filename
         Object configurationPath = properties.get("felix.fileinstall.filename");
         if (configurationPath == null) {
             throw new ConfigurationException("felix.fileinstall.filename", "Missing configuration filename");
         }
-        logger.info("Updating configuration file: {} (pid: {})", configurationPath, pid);
         String configurationName = FilenameUtils.getBaseName(configurationPath.toString());
         String siteKey = StringUtils.substringAfter(configurationName, "-");
 
-        SitePolicy sitePolicy = createSitePolicy(properties, configurationPath);
+        // build the site policy for the site
+        SitePolicy sitePolicy = SitePolicy.SitePolicyBuilder.build(properties);
 
-        policyByPid.put(pid, sitePolicy);
-        if (StringUtils.isEmpty(siteKey)) {
-            defaultPid.set(pid);
-            logger.debug("Default site policy updated.");
-        } else {
-            pidBySite.put(siteKey, pid);
-            logger.debug("Site policy for '{}' updated.", siteKey);
-        }
+        // update the maps
+        policiesBySiteKey.put(siteKey, sitePolicy);
+        sitesByPid.put(pid, siteKey);
+
+        logger.info("Site policy for {} (pid: {}) updated.", siteKey, pid);
     }
 
     @Override
     public void deleted(String pid) {
-        logger.debug("Deleting configuration for pid {}", pid);
-        policyByPid.remove(pid);
-        if (defaultPid.compareAndSet(pid, null)) {
-            logger.info("Default site policy deleted.");
-        } else {
-            logger.info("Deleting site policy for site '{}'", pidBySite.remove(pid));
-        }
-    }
+        String siteKey = sitesByPid.remove(pid);
+        policiesBySiteKey.remove(siteKey);
 
-    private SitePolicy createSitePolicy(Dictionary<String, ?> properties, Object configurationPath) throws ConfigurationException {
-        // convert the dictionary to a map and keep only the props starting with "htmlFiltering."
-        List<String> keys = Collections.list(properties.keys());
-        Map<String, Object> propertiesMap = keys.stream()
-                .filter(key -> key.startsWith("htmlFiltering."))
-                .collect(Collectors.toMap(k -> StringUtils.substringAfter(k, "htmlFiltering."), properties::get));
-
-        // convert the map to a configuration object
-        SiteCfg siteConfiguration;
-        try {
-            String propertiesMapAsString = javaPropsMapper.writeValueAsString(propertiesMap);
-            siteConfiguration = javaPropsMapper.readValue(propertiesMapAsString, SiteCfg.class);
-        } catch (JsonProcessingException e) {
-            throw new ConfigurationException(null, "Unable to read the configuration file: " + configurationPath, e);
-        }
-        logger.debug("Site configuration loaded: {}", siteConfiguration);
-
-        return new SitePolicy(siteConfiguration);
+        logger.info("Site policy for {} (pid: {}) deleted.", siteKey, pid);
     }
 
     @Override
     public Policy getPolicy(String siteKey, String workspaceName) {
-        String pid = pidBySite.get(siteKey);
-        if (pid == null) {
-            logger.debug("No pid found for siteKey: {}, using default policy", siteKey);
-            pid = defaultPid.get();
+        // 1) site-specific configuration
+        SitePolicy sitePolicy = policiesBySiteKey.get(siteKey);
+        if (sitePolicy != null) {
+            logger.debug("Site policy found for siteKey: {}", siteKey);
+            return sitePolicy.getPolicy(workspaceName);
         }
-        logger.debug("pid for site {}: {}", siteKey, pid);
-        SitePolicy policy = policyByPid.get(pid);
-        if (policy == null) {
-            logger.debug("No policy available for siteKey: {}", siteKey);
-            return null;
+
+        // 2) default configuration
+        sitePolicy = defaultSitePolicyService.getSitePolicy();
+        if (sitePolicy != null) {
+            logger.debug("Default site policy found");
+            return sitePolicy.getPolicy(workspaceName);
         }
-        return policy.getPolicy(workspaceName);
+
+        // 3) fallback configuration
+        sitePolicy = fallbackSitePolicyService.getSitePolicy();
+        if (sitePolicy != null) {
+            logger.debug("Fallback site policy found");
+            return sitePolicy.getPolicy(workspaceName);
+        }
+        logger.debug("No site policy found for siteKey: {}, workspaceName: {}", siteKey, workspaceName);
+        return null;
     }
-
-    private static final class SitePolicy {
-
-        private final Policy editWorkspacePolicy;
-        private final Policy liveWorkspacePolicy;
-
-        private SitePolicy(SiteCfg siteConfiguration) {
-            // compile the regex patterns for the allowed and disallowed rule sets (shared for both workspaces)
-            Map<String, Pattern> formatPatterns = new HashMap<>();
-            if (siteConfiguration.getFormatDefinitions() != null) {
-                siteConfiguration.getFormatDefinitions().forEach((formatName, formatRegex) -> {
-                    formatPatterns.put(formatName, Pattern.compile(formatRegex)); // TODO properly throw meaningful exception if invalid regex
-                    logger.debug("Compiled format {} regex: {}", formatName, formatRegex);
-                });
-            }
-            editWorkspacePolicy = new PolicyImpl(formatPatterns, siteConfiguration.getEditWorkspace());
-            liveWorkspacePolicy = new PolicyImpl(formatPatterns, siteConfiguration.getLiveWorkspace());
-        }
-
-        private Policy getPolicy(String workspaceName) {
-            if (Constants.EDIT_WORKSPACE.equals(workspaceName)) {
-                return editWorkspacePolicy;
-            }
-            if (!Constants.LIVE_WORKSPACE.equals(workspaceName)) {
-                logger.warn("Unknown workspace name: {}, fallback to using live workspace policy", workspaceName);
-            }
-            return liveWorkspacePolicy;
-        }
-    }
-
 }

--- a/src/main/java/org/jahia/modules/htmlfiltering/impl/SitePolicy.java
+++ b/src/main/java/org/jahia/modules/htmlfiltering/impl/SitePolicy.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2002-2025 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.htmlfiltering.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.dataformat.javaprop.JavaPropsMapper;
+import org.apache.commons.lang3.StringUtils;
+import org.jahia.api.Constants;
+import org.jahia.modules.htmlfiltering.Policy;
+import org.jahia.modules.htmlfiltering.configuration.SiteCfg;
+import org.osgi.service.cm.ConfigurationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+final class SitePolicy {
+
+    private static final Logger logger = LoggerFactory.getLogger(SitePolicy.class);
+    private final Policy editWorkspacePolicy;
+    private final Policy liveWorkspacePolicy;
+
+    SitePolicy(SiteCfg siteConfiguration) {
+        // compile the regex patterns for the allowed and disallowed rule sets (shared for both workspaces)
+        Map<String, Pattern> formatPatterns = new HashMap<>();
+        if (siteConfiguration.getFormatDefinitions() != null) {
+            siteConfiguration.getFormatDefinitions().forEach((formatName, formatRegex) -> {
+                formatPatterns.put(formatName, Pattern.compile(formatRegex)); // TODO properly throw meaningful exception if invalid regex
+                logger.debug("Compiled format {} regex: {}", formatName, formatRegex);
+            });
+        }
+        editWorkspacePolicy = new PolicyImpl(formatPatterns, siteConfiguration.getEditWorkspace());
+        liveWorkspacePolicy = new PolicyImpl(formatPatterns, siteConfiguration.getLiveWorkspace());
+    }
+
+    Policy getPolicy(String workspaceName) {
+        if (Constants.EDIT_WORKSPACE.equals(workspaceName)) {
+            return editWorkspacePolicy;
+        }
+        if (!Constants.LIVE_WORKSPACE.equals(workspaceName)) {
+            logger.warn("Unknown workspace name: {}, fallback to using live workspace policy", workspaceName);
+        }
+        return liveWorkspacePolicy;
+    }
+
+    static class SitePolicyBuilder {
+        private final static JavaPropsMapper javaPropsMapper = JavaPropsMapper.builder()
+                .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, true)
+                .configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false)
+                .build();
+
+        static SitePolicy build(Dictionary<String, ?> properties) throws ConfigurationException {
+            // convert the dictionary to a map and keep only the props starting with "htmlFiltering."
+            List<String> keys = Collections.list(properties.keys());
+            Map<String, Object> propertiesMap = keys.stream()
+                    .filter(key -> key.startsWith("htmlFiltering."))
+                    .collect(Collectors.toMap(k -> StringUtils.substringAfter(k, "htmlFiltering."), properties::get));
+
+            // convert the map to a configuration object
+            SiteCfg siteConfiguration;
+            try {
+                String propertiesMapAsString = javaPropsMapper.writeValueAsString(propertiesMap);
+                siteConfiguration = javaPropsMapper.readValue(propertiesMapAsString, SiteCfg.class);
+            } catch (JsonProcessingException e) {
+                throw new ConfigurationException(null, "Unable to read the properties: " + properties, e);
+            }
+            logger.debug("Site configuration loaded: {}", siteConfiguration);
+
+            return new SitePolicy(siteConfiguration);
+        }
+    }
+}

--- a/src/main/resources/META-INF/configurations/org.jahia.modules.htmlfiltering.default.yml
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.htmlfiltering.default.yml
@@ -1,0 +1,118 @@
+# default configuration
+htmlFiltering:
+  formatDefinitions:
+    HTML_ID: '[a-zA-Z0-9\:\-_\.]+'
+    NUMBER_OR_PERCENT: '\d+%?'
+    LINKS_URL: '(?:(?:[\p{L}\p{N}\\\.#@$%\+&;\-_~,\?=/!{}:]+|#(\w)+)|(\s*(?:(?:ht|f)tps?://|mailto:)[\p{L}\p{N}][\p{L}\p{N}\p{Zs}\.#@$%\+&:\-_~,\?=/!\(\)]*+\s*))'
+  editWorkspace:
+    strategy: SANITIZE
+    allowedRuleSet:
+      elements:
+        - attributes: [class, dir, hidden, lang, role, style, title]
+        - attributes:
+            - id
+          format: HTML_ID
+        - attributes: [align]
+          tags: [caption, col, colgroup, hr, img, table, tbody, td, tfoot, th, thead, tr]
+        - attributes: [alt]
+          tags: [img]
+        - attributes: [autoplay, controls, loop, muted, preload]
+          tags: [audio, video]
+        - attributes: [cite]
+          tags: [blockquote, del, ins, q]
+        - attributes: [colspan, rowspan]
+          tags: [td, th]
+        - attributes: [crossorigin]
+          tags: [audio, img, source, video]
+        - attributes: [datetime]
+          tags: [del, ins, time]
+        - attributes: [disabled]
+          tags: [button]
+        - attributes: [download]
+          tags: [a]
+        - attributes: [headers]
+          tags: [td, th]
+        - attributes: [height, width]
+          tags: [canvas, img, table, td, th, col, colgroup, video]
+          format: NUMBER_OR_PERCENT
+        - attributes: [href]
+          tags: [a]
+          format: LINKS_URL
+        - attributes: [hreflang]
+          tags: [a]
+        - attributes: [kind, label]
+          tags: [track]
+        - attributes: [media, rel]
+          tags: [a]
+        - attributes: [src]
+          tags: [audio, img, source, track, video]
+        - attributes: [srcset]
+          tags: [img, source]
+        - attributes: [type]
+          tags: [ol, ul]
+        - attributes: [target]
+          tags: [a, source]
+        - attributes: [type]
+          tags: [a, blockquote, button, col, del, ins, link, q]
+        - attributes: [value]
+          tags: [li]
+        - attributes: [border, cellpadding, cellspacing, summary]
+          tags: [table]
+        - tags: [h1, h2, h3, h4, h5, h6, hgroup, p, a, img, figure, figcaption, canvas, picture, br, strong, b, em, i, span, div, ul, ol, li, dl, dd, dt, table, tbody, thead, tfoot, tr, td, th, col, colgroup, caption, blockquote, q, cite, code, pre, var, abbr, address, del, s, details, summary, ins, sub, sup, small, mark, hr, button, legend, audio, video, source, track, nav, article, main, aside, section, time, header, footer, wbr, u]
+      protocols: [http, https, mailto]
+  liveWorkspace:
+    strategy: SANITIZE
+    allowedRuleSet:
+      elements:
+        - attributes: [class, dir, hidden, lang, role, style]
+        - attributes:
+            - id
+          format: HTML_ID
+        - attributes: [align]
+          tags: [caption, col, colgroup, hr, img, table, tbody, td, tfoot, th, thead, tr]
+        - attributes: [alt]
+          tags: [img]
+        - attributes: [autoplay, controls, loop, muted, preload]
+          tags: [audio, video]
+        - attributes: [cite]
+          tags: [blockquote, del, ins, q]
+        - attributes: [colspan, rowspan]
+          tags: [td, th]
+        - attributes: [crossorigin]
+          tags: [audio, img, source, video]
+        - attributes: [datetime]
+          tags: [del, ins, time]
+        - attributes: [disabled]
+          tags: [button]
+        - attributes: [download]
+          tags: [a]
+        - attributes: [headers]
+          tags: [td, th]
+        - attributes: [height, width]
+          tags: [canvas, img, table, td, th, col, colgroup, video]
+          format: NUMBER_OR_PERCENT
+        - attributes: [href]
+          tags: [a]
+          format: LINKS_URL
+        - attributes: [hreflang]
+          tags: [a]
+        - attributes: [kind, label]
+          tags: [track]
+        - attributes: [media, rel]
+          tags: [a]
+        - attributes: [src]
+          tags: [audio, img, source, track, video]
+        - attributes: [srcset]
+          tags: [img, source]
+        - attributes: [type]
+          tags: [ol, ul]
+        - attributes: [target]
+          tags: [a, source]
+        - attributes: [type]
+          tags: [a, blockquote, button, col, del, ins, link, q]
+        - attributes: [value]
+          tags: [li]
+        - attributes: [border, cellpadding, cellspacing, summary]
+          tags: [table]
+        - tags: [h1, h2, h3, h4, h5, h6, hgroup, p, a, img, figure, figcaption, canvas, picture, br, strong, b, em, i, span, div, ul, ol, li, dl, dd, dt, table, tbody, thead, tfoot, tr, td, th, col, colgroup, caption, blockquote, q, cite, code, pre, var, abbr, address, del, s, details, summary, ins, sub, sup, small, mark, hr, button, legend, audio, video, source, track, nav, article, main, aside, section, time, header, footer, wbr, u]
+      protocols: [http, https, mailto]

--- a/src/main/resources/META-INF/configurations/org.jahia.modules.htmlfiltering.fallback.yml
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.htmlfiltering.fallback.yml
@@ -1,5 +1,4 @@
-# TODO add header to tell that this file should not be overwritten
-
+# fallback configuration
 htmlFiltering:
   formatDefinitions:
     HTML_ID: '[a-zA-Z0-9\:\-_\.]+'


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

Relates to https://github.com/Jahia/html-filtering/issues/66.

## Description
Introduce a fallback strategy to be used when there is no site-specific or default configuration provided.
Policy resolution strategy:
1. Site-specific configuration: `org.jahia.modules.htmlfiltering-<site key>.yml` found in any OSGi bundle
2. Default configuration: `org.jahia.modules.htmlfiltering.default.yml` found in any OSGi bundle, to configure multiple sites that do not have a site-specific configuration provided
3. Fallback configuration: `org.jahia.modules.htmlfiltering.fallback.yml` provided by the _HTML Filtering_ bundle

Only the first 2 configurations are meant to be defined by customers as the fallback one may change with module updates.

## Technical notes

The shared logic to create Java POJO objects from the configuration files has been extracted to `SitePolicy` and its internal `SitePolicyBuilder` classes.
