### PR TITLE
test: add testing for policy resolution strategy

### DIFF
--- a/tests/cypress/e2e/configurationStrategy.cy.ts
+++ b/tests/cypress/e2e/configurationStrategy.cy.ts
@@ -8,7 +8,7 @@ describe('Test the configuration strategy used by the HTML filtering module', ()
     const OTHER_SITE = 'otherSite'; // Site that does not have a configuration for the module
     const RICH_TEXT_NODE = 'testRichTextNode';
     const PATH = `/sites/${SITE_KEY}/home/pagecontent/${RICH_TEXT_NODE}`;
-    const HTML_TEXT = '<h1 id="_invalid">my title</h1><p id="abc" class="myClass">my text</p>';
+    const HTML_TEXT = '<h1 id="@invalid">my title</h1><p id="abc" class="myClass">my text</p>';
     const EXPECTED_HTML_TEXT_WITH_FALLBACK = '<h1>my title</h1><p id="abc" class="myClass">my text</p>';
     const EXPECTED_HTML_TEXT_WITH_DEFAULT = 'my title<p id="abc">my text</p>';
     const EXPECTED_HTML_TEXT_WITH_PER_SITE = '<h1>my title</h1><p>my text</p>';
@@ -43,6 +43,7 @@ describe('Test the configuration strategy used by the HTML filtering module', ()
 
     it('when only a default configuration is provided, the HTML text is sanitized using the default strategy', () => {
         installConfig('configs/configurationStrategy/org.jahia.modules.htmlfiltering.default.yml');
+
         modifyContent(PATH, HTML_TEXT);
         getContent(PATH).then(result => {
             const value = result.data.jcr.nodeByPath.property.value;
@@ -53,42 +54,53 @@ describe('Test the configuration strategy used by the HTML filtering module', ()
 
     it('when only a per-site configuration is provided, the HTML text is sanitized using the per-site strategy', () => {
         installConfig(`configs/configurationStrategy/org.jahia.modules.htmlfiltering-${SITE_KEY}.yml`);
+
         modifyContent(PATH, HTML_TEXT);
         getContent(PATH).then(result => {
             const value = result.data.jcr.nodeByPath.property.value;
             expect(value).to.be.equal(EXPECTED_HTML_TEXT_WITH_PER_SITE);
         });
+
         removeSiteConfig(SITE_KEY);
     });
 
     it('when a default and a per-site configuration is provided, the HTML text is sanitized using the per-site strategy', () => {
         installConfig('configs/configurationStrategy/org.jahia.modules.htmlfiltering.default.yml');
         installConfig(`configs/configurationStrategy/org.jahia.modules.htmlfiltering-${SITE_KEY}.yml`);
+
         modifyContent(PATH, HTML_TEXT);
         getContent(PATH).then(result => {
             const value = result.data.jcr.nodeByPath.property.value;
             expect(value).to.be.equal(EXPECTED_HTML_TEXT_WITH_PER_SITE);
         });
+
         removeSiteConfig(SITE_KEY);
         removeDefaultConfig();
     });
 
     it('when only a per-site configuration for another site is provided, the HTML text is sanitized using the fallback strategy', () => {
-        installConfig(`configs/configurationStrategy/org.jahia.modules.htmlfiltering-${SITE_KEY}.yml`);
+        installConfig(`configs/configurationStrategy/org.jahia.modules.htmlfiltering-${OTHER_SITE}.yml`);
+
         modifyContent(PATH, HTML_TEXT);
         getContent(PATH).then(result => {
             const value = result.data.jcr.nodeByPath.property.value;
-            expect(value).to.be.equal(EXPECTED_HTML_TEXT_WITH_PER_SITE);
+            expect(value).to.be.equal(EXPECTED_HTML_TEXT_WITH_FALLBACK);
         });
-        removeSiteConfig(SITE_KEY);
+
+        removeSiteConfig(OTHER_SITE);
     });
+
     it('when a default and a per-site configuration for another site is provided, the HTML text is sanitized using the default strategy', () => {
-        installConfig(`configs/configurationStrategy/org.jahia.modules.htmlfiltering-${SITE_KEY}.yml`);
+        installConfig('configs/configurationStrategy/org.jahia.modules.htmlfiltering.default.yml');
+        installConfig(`configs/configurationStrategy/org.jahia.modules.htmlfiltering-${OTHER_SITE}.yml`);
+
         modifyContent(PATH, HTML_TEXT);
         getContent(PATH).then(result => {
             const value = result.data.jcr.nodeByPath.property.value;
-            expect(value).to.be.equal(EXPECTED_HTML_TEXT_WITH_PER_SITE);
+            expect(value).to.be.equal(EXPECTED_HTML_TEXT_WITH_DEFAULT);
         });
-        removeSiteConfig(SITE_KEY);
+
+        removeSiteConfig(OTHER_SITE);
+        removeDefaultConfig();
     });
 });

--- a/tests/cypress/e2e/configurationStrategy.cy.ts
+++ b/tests/cypress/e2e/configurationStrategy.cy.ts
@@ -1,0 +1,74 @@
+import {addNode, createSite, deleteSite} from '@jahia/cypress';
+import {getContent, installConfig, modifyContent, removeDefaultConfig, removeSiteConfig} from '../fixtures/utils';
+// NB: this is not intended to be a comprehensive tests suite for the sanitization, but rather a quick sanity check
+//     to ensure that the right policy is used for a given site, depending on the configuration in place.
+//     For comprehensive tests, see PolicyImplTest.
+describe('Test the configuration strategy used by the HTML filtering module', () => {
+    const SITE_KEY = 'testHtmlFilteringConfigurationStrategy';
+    const RICH_TEXT_NODE = 'testRichTextNode';
+    const PATH = `/sites/${SITE_KEY}/home/pagecontent/${RICH_TEXT_NODE}`;
+    const HTML_TEXT = '<h1>my title</h1><p id="abc" class="myClass">my text</p>';
+    const EXPECTED_HTML_TEXT_WITH_FALLBACK = '<h1>my title</h1><p id="abc" class="myClass">my text</p>';
+    const EXPECTED_HTML_TEXT_WITH_DEFAULT = 'my title<p id="abc">my text</p>';
+    const EXPECTED_HTML_TEXT_WITH_PER_SITE = '<h1>my title</h1><p>my text</p>';
+
+    before(() => {
+        // Create a site with an empty rich text component on the home page to store the HTML text to be filtered
+        createSite(SITE_KEY, {locale: 'en', serverName: 'localhost', templateSet: 'html-filtering-test-module'});
+        addNode({
+            parentPathOrId: `/sites/${SITE_KEY}/home`,
+            name: 'pagecontent',
+            primaryNodeType: 'jnt:contentList',
+            children: [
+                {
+                    name: RICH_TEXT_NODE,
+                    primaryNodeType: 'jnt:bigText',
+                    properties: [{name: 'text', value: '', language: 'en'}]
+                }
+            ]
+        });
+    });
+    after(() => {
+        deleteSite(SITE_KEY);
+    });
+
+    it('when no configuration is provided, the HTML text is sanitized using the fallback strategy', () => {
+        modifyContent(PATH, HTML_TEXT);
+        getContent(PATH).then(result => {
+            const value = result.data.jcr.nodeByPath.property.value;
+            expect(value).to.be.equal(EXPECTED_HTML_TEXT_WITH_FALLBACK);
+        });
+    });
+
+    it('when a default configuration is provided, the HTML text is sanitized using the default strategy', () => {
+        installConfig('configs/configurationStrategy/org.jahia.modules.htmlfiltering.default.yml');
+        modifyContent(PATH, HTML_TEXT);
+        getContent(PATH).then(result => {
+            const value = result.data.jcr.nodeByPath.property.value;
+            expect(value).to.be.equal(EXPECTED_HTML_TEXT_WITH_DEFAULT);
+        });
+        removeDefaultConfig();
+    });
+
+    it('when only a per-site configuration is provided, the HTML text is sanitized using the per-site strategy', () => {
+        installConfig(`configs/configurationStrategy/org.jahia.modules.htmlfiltering-${SITE_KEY}.yml`);
+        modifyContent(PATH, HTML_TEXT);
+        getContent(PATH).then(result => {
+            const value = result.data.jcr.nodeByPath.property.value;
+            expect(value).to.be.equal(EXPECTED_HTML_TEXT_WITH_PER_SITE);
+        });
+        removeSiteConfig(SITE_KEY);
+    });
+
+    it('when a default and per-site configuration is provided, the HTML text is sanitized using the per-site strategy', () => {
+        installConfig('configs/configurationStrategy/org.jahia.modules.htmlfiltering.default.yml');
+        installConfig(`configs/configurationStrategy/org.jahia.modules.htmlfiltering-${SITE_KEY}.yml`);
+        modifyContent(PATH, HTML_TEXT);
+        getContent(PATH).then(result => {
+            const value = result.data.jcr.nodeByPath.property.value;
+            expect(value).to.be.equal(EXPECTED_HTML_TEXT_WITH_PER_SITE);
+        });
+        removeSiteConfig(SITE_KEY);
+        removeDefaultConfig();
+    });
+});

--- a/tests/cypress/fixtures/configs/configurationStrategy/org.jahia.modules.htmlfiltering-otherSite.yml
+++ b/tests/cypress/fixtures/configs/configurationStrategy/org.jahia.modules.htmlfiltering-otherSite.yml
@@ -1,0 +1,6 @@
+htmlFiltering:
+  editWorkspace:
+    strategy: SANITIZE
+    allowedRuleSet:
+      elements:
+        - tags: [p, h1]

--- a/tests/cypress/fixtures/configs/configurationStrategy/org.jahia.modules.htmlfiltering-testHtmlFilteringConfigurationStrategy.yml
+++ b/tests/cypress/fixtures/configs/configurationStrategy/org.jahia.modules.htmlfiltering-testHtmlFilteringConfigurationStrategy.yml
@@ -1,0 +1,6 @@
+htmlFiltering:
+  editWorkspace:
+    strategy: SANITIZE
+    allowedRuleSet:
+      elements:
+        - tags: [p, h1]

--- a/tests/cypress/fixtures/configs/configurationStrategy/org.jahia.modules.htmlfiltering.default.yml
+++ b/tests/cypress/fixtures/configs/configurationStrategy/org.jahia.modules.htmlfiltering.default.yml
@@ -1,0 +1,7 @@
+htmlFiltering:
+  editWorkspace:
+    strategy: SANITIZE
+    allowedRuleSet:
+      elements:
+        - attributes: [id]
+        - tags: [p]

--- a/tests/cypress/fixtures/groovy/removeConfig.groovy
+++ b/tests/cypress/fixtures/groovy/removeConfig.groovy
@@ -7,8 +7,10 @@ def pid = "PID"
 def identifier = "IDENTIFIER"
 Config conf
 if ("".equals(identifier)) {
+    log.info("Deleting config by pid '{}'", pid)
     conf = configService.getConfig(pid)
 } else {
+    log.info("Deleting config by pid '{}' and identifier '{}'", pid, identifier)
     conf = configService.getConfig(pid, identifier)
 }
 def filename = conf.getIdentifier() // conf.getProperties().get("felix.fileinstall.filename");

--- a/tests/cypress/fixtures/utils/configuration.ts
+++ b/tests/cypress/fixtures/utils/configuration.ts
@@ -10,22 +10,12 @@ export const installConfig = configFilePath => {
     );
 };
 
-export const getConfig = siteKey => {
-    const getConfigGql = gql`
-        query getConfig($pid: String!, $siteKey: String!) {
-            admin {
-                jahia {
-                    configuration(pid: $pid, identifier: $siteKey) {
-                        flatKeys
-                    }
-                }
-            }
-        }
-    `;
-    return cy.apollo({
-        query: getConfigGql,
-        variables: {pid, siteKey}
-    });
+export const removeDefaultConfig = () => {
+    executeGroovy('groovy/removeConfig.groovy', {PID: 'org.jahia.modules.htmlfiltering.default', IDENTIFIER: ''});
+};
+
+export const removeSiteConfig = siteKey => {
+    executeGroovy('groovy/removeConfig.groovy', {PID: 'org.jahia.modules.htmlfiltering', IDENTIFIER: siteKey});
 };
 
 export const removeConfig = siteKey => {


### PR DESCRIPTION
Closes https://github.com/Jahia/html-filtering/issues/66 and related to the changes in https://github.com/Jahia/html-filtering/pull/77.

## Description

Add Cypress tests for the policy resolution strategy, to ensure that the right policy is used for a given site, depending on the configuration in place.
Related to the
