### PR TITLE
ci(tests): Fix distribution management URLs for the test module

### DIFF
--- a/tests/jahia-module/pom.xml
+++ b/tests/jahia-module/pom.xml
@@ -49,20 +49,16 @@
         </repository>
     </repositories>
 
-  <distributionManagement>
-      <repository>
-          <id>jahia-enterprise-customers-releases</id>
-          <url>https://devtools.jahia.com/nexus/content/repositories/jahia-enterprise-customers-releases</url>
-      </repository>
-      <snapshotRepository>
-          <id>jahia-enterprise-customers-snapshots</id>
-          <url>https://devtools.jahia.com/nexus/content/repositories/jahia-enterprise-customers-snapshots</url>
-      </snapshotRepository>
-      <site>
-          <id>jahia.website</id>
-          <url>file://${jahia.site.path}</url>
-      </site>
-  </distributionManagement>
+    <distributionManagement>
+        <repository>
+            <id>jahia-releases</id>
+            <url>https://devtools.jahia.com/nexus/content/repositories/jahia-releases</url>
+        </repository>
+        <snapshotRepository>
+            <id>jahia-snapshots</id>
+            <url>https://devtools.jahia.com/nexus/content/repositories/jahia-snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
 
     <build>
         <plugins>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

Fix the "Publish module" step of the "on merge to master" workflow that is currently broken.
See [this failure](https://github.com/Jahia/html-filtering/actions/runs/15068579071/job/42359106932). Current error:
```
Error:  Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy (default-deploy) on project html-filtering-test-module: Failed to retrieve remote metadata org.jahia.test:html-filtering-test-module:2.0.0-SNAPSHOT/maven-metadata.xml: Could not transfer metadata org.jahia.test:html-filtering-test-module:2.0.0-SNAPSHOT/maven-metadata.xml from/to jahia-enterprise-customers-snapshots (https://devtools.jahia.com/nexus/content/repositories/jahia-enterprise-customers-snapshots): authentication failed for https://devtools.jahia.com/nexus/content/repositories/jahia-enterprise-customers-snapshots/org/jahia/test/html-filtering-test-module/2.0.0-SNAPSHOT/maven-metadata.xml, status: 401 Unauthorized -> [Help 1]
```

