### PR TITLE
feat: Explicit declaration in configuration files

### DIFF
--- a/src/main/java/org/jahia/modules/htmlfiltering/configuration/WorkspaceCfg.java
+++ b/src/main/java/org/jahia/modules/htmlfiltering/configuration/WorkspaceCfg.java
@@ -24,7 +24,7 @@ import javax.jcr.Value;
 public class WorkspaceCfg {
     private RuleSetCfg allowedRuleSet;
     private RuleSetCfg disallowedRuleSet;
-    private StrategyCfg strategy = StrategyCfg.SANITIZE;
+    private StrategyCfg strategy;
 
     public RuleSetCfg getAllowedRuleSet() {
         return allowedRuleSet;

--- a/src/main/java/org/jahia/modules/htmlfiltering/impl/PolicyImpl.java
+++ b/src/main/java/org/jahia/modules/htmlfiltering/impl/PolicyImpl.java
@@ -53,9 +53,6 @@ final class PolicyImpl implements Policy {
         if (workspace == null) {
             throw new IllegalArgumentException("Workspace configuration is not set");
         }
-        if (workspace.getStrategy() == null) {
-            throw new IllegalArgumentException("'strategy' is not set");
-        }
         this.strategy = readStrategy(workspace);
         if (workspace.getAllowedRuleSet() == null) {
             throw new IllegalArgumentException("'allowedRuleSet' is not set");
@@ -69,6 +66,9 @@ final class PolicyImpl implements Policy {
     }
 
     private static Strategy readStrategy(WorkspaceCfg workspace) {
+        if (workspace.getStrategy() == null) {
+            throw new IllegalArgumentException("'strategy' is not set");
+        }
         switch (workspace.getStrategy()) {
             case REJECT:
                 return Strategy.REJECT;

--- a/src/main/java/org/jahia/modules/htmlfiltering/impl/PolicyImpl.java
+++ b/src/main/java/org/jahia/modules/htmlfiltering/impl/PolicyImpl.java
@@ -56,7 +56,7 @@ final class PolicyImpl implements Policy {
         if (workspace.getStrategy() == null) {
             throw new IllegalArgumentException("'strategy' is not set");
         }
-        this.strategy = WorkspaceCfg.StrategyCfg.REJECT.equals(workspace.getStrategy()) ? Strategy.REJECT : Strategy.SANITIZE;
+        this.strategy = readStrategy(workspace);
         if (workspace.getAllowedRuleSet() == null) {
             throw new IllegalArgumentException("'allowedRuleSet' is not set");
         }
@@ -66,6 +66,17 @@ final class PolicyImpl implements Policy {
         processRuleSet(builder, workspace.getDisallowedRuleSet(), formatPatterns,
                 HtmlPolicyBuilder::disallowAttributes, HtmlPolicyBuilder::disallowElements, HtmlPolicyBuilder::disallowUrlProtocols);
         this.policyFactory = builder.toFactory();
+    }
+
+    private static Strategy readStrategy(WorkspaceCfg workspace) {
+        switch (workspace.getStrategy()) {
+            case REJECT:
+                return Strategy.REJECT;
+            case SANITIZE:
+                return Strategy.SANITIZE;
+            default:
+                throw new IllegalArgumentException(String.format("Unknown 'strategy':%s ", workspace.getStrategy()));
+        }
     }
 
     private static void processRuleSet(HtmlPolicyBuilder builder, RuleSetCfg ruleSet,

--- a/src/main/java/org/jahia/modules/htmlfiltering/impl/SitePolicy.java
+++ b/src/main/java/org/jahia/modules/htmlfiltering/impl/SitePolicy.java
@@ -46,8 +46,17 @@ final class SitePolicy {
                 logger.debug("Compiled format {} regex: {}", formatName, formatRegex);
             });
         }
-        editWorkspacePolicy = new PolicyImpl(formatPatterns, siteConfiguration.getEditWorkspace());
-        liveWorkspacePolicy = new PolicyImpl(formatPatterns, siteConfiguration.getLiveWorkspace());
+        try {
+            editWorkspacePolicy = new PolicyImpl(formatPatterns, siteConfiguration.getEditWorkspace());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unable to create the policy for the 'editWorkspace', reason: " + e.getMessage(), e);
+        }
+        try {
+            liveWorkspacePolicy = new PolicyImpl(formatPatterns, siteConfiguration.getLiveWorkspace());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unable to create the policy for the 'liveWorkspace', reason: " + e.getMessage(), e);
+        }
+
     }
 
     Policy getPolicy(String workspaceName) {

--- a/src/test/java/org/jahia/modules/htmlfiltering/impl/PolicyImplTest.java
+++ b/src/test/java/org/jahia/modules/htmlfiltering/impl/PolicyImplTest.java
@@ -10,13 +10,76 @@ import org.jahia.modules.htmlfiltering.configuration.WorkspaceCfg;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnitParamsRunner.class)
 public class PolicyImplTest {
+
+    @Test
+    public void GIVEN_a_null_workspace_WHEN_creating_policy_THEN_exception_is_thrown() {
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> new PolicyImpl(Collections.emptyMap(), null));
+
+        assertEquals("Workspace configuration is not set", exception.getMessage());
+    }
+
+    @Test
+    public void GIVEN_a_null_strategy_WHEN_creating_policy_THEN_exception_is_thrown() {
+
+        WorkspaceCfg workspace = new WorkspaceCfg();
+        workspace.setStrategy(null); // null 'strategy'
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> new PolicyImpl(Collections.emptyMap(), workspace));
+
+        assertEquals("'strategy' is not set", exception.getMessage());
+    }
+
+    @Test
+    public void GIVEN_a_null_allowedRuleSet_WHEN_creating_policy_THEN_exception_is_thrown() {
+
+        WorkspaceCfg workspace = new WorkspaceCfg();
+        workspace.setStrategy(WorkspaceCfg.StrategyCfg.REJECT);
+        workspace.setAllowedRuleSet(null); // null 'allowedRuleSet'
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> new PolicyImpl(Collections.emptyMap(), workspace));
+
+        assertEquals("'allowedRuleSet' is not set", exception.getMessage());
+    }
+
+    @Test
+    public void GIVEN_null_elements_in_allowedRuleSet_WHEN_creating_policy_THEN_exception_is_thrown() {
+
+        WorkspaceCfg workspace = new WorkspaceCfg();
+        workspace.setStrategy(WorkspaceCfg.StrategyCfg.REJECT);
+        RuleSetCfg allowedRuleSet = new RuleSetCfg();
+        allowedRuleSet.setElements(null);// null 'elements'
+        workspace.setAllowedRuleSet(allowedRuleSet);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> new PolicyImpl(Collections.emptyMap(), workspace));
+
+        assertEquals("At least one item in 'elements' must be defined", exception.getMessage());
+    }
+
+    @Test
+    public void GIVEN_empty_elements_in_allowedRuleSet_WHEN_creating_policy_THEN_exception_is_thrown() {
+
+        WorkspaceCfg workspace = new WorkspaceCfg();
+        workspace.setStrategy(WorkspaceCfg.StrategyCfg.REJECT);
+        RuleSetCfg allowedRuleSet = new RuleSetCfg();
+        allowedRuleSet.setElements(of()); // empty 'elements'
+        workspace.setAllowedRuleSet(allowedRuleSet);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> new PolicyImpl(Collections.emptyMap(), workspace));
+
+        assertEquals("At least one item in 'elements' must be defined", exception.getMessage());
+    }
 
     @Test
     public void GIVEN_element_without_attributes_and_tags_WHEN_creating_policy_THEN_exception_is_thrown() {
@@ -30,7 +93,7 @@ public class PolicyImplTest {
 
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> new PolicyImpl(Collections.emptyMap(), workspace));
 
-        assertEquals("Each item in the 'elements' of an 'allowedRuleSet' / 'disallowedRuleSet' must contain 'tags' and/or 'attributes'. Item: " + element, exception.getMessage());
+        assertEquals("Each item in 'elements' of 'allowedRuleSet' / 'disallowedRuleSet' must contain 'tags' and/or 'attributes'. Item: " + element, exception.getMessage());
     }
 
     @Test
@@ -64,20 +127,6 @@ public class PolicyImplTest {
     }
 
     @Test
-    public void GIVEN_a_null_workspace_WHEN_creating_policy_THEN_the_default_strategy_is_to_sanitize() {
-        WorkspaceCfg workspace = new WorkspaceCfg();
-        RuleSetCfg allowedRuleSet = new RuleSetCfg();
-        workspace.setAllowedRuleSet(allowedRuleSet);
-        allowedRuleSet.setElements(of(
-                buildElement(null, of("id"), "UNDEFINED_FORMAT")
-        ));
-
-        PolicyImpl policy = new PolicyImpl(Collections.emptyMap(), null);
-
-        assertEquals(Strategy.SANITIZE, policy.getStrategy());
-    }
-
-    @Test
     @Parameters({
             "REJECT, REJECT",
             "SANITIZE, SANITIZE",
@@ -85,6 +134,10 @@ public class PolicyImplTest {
     public void GIVEN_a_workspace_with_a_specific_strategy_WHEN_creating_policy_THEN_the_strategy_matches(WorkspaceCfg.StrategyCfg strategyCfg, Strategy expectedStrategy) {
         WorkspaceCfg workspace = new WorkspaceCfg();
         workspace.setStrategy(strategyCfg);
+        workspace.setAllowedRuleSet(new RuleSetCfg());
+        workspace.getAllowedRuleSet().setElements(of(
+                buildElement(of("p"), null, null)
+        ));
 
         PolicyImpl policy = new PolicyImpl(Collections.emptyMap(), workspace);
 
@@ -100,8 +153,14 @@ public class PolicyImplTest {
             // invalid HTML content is removed but content is kept:
             "<p>my text<h1>title</h6>, my texttitle"
     })
-    public void GIVEN_empty_configuration_WHEN_sanitizing_THEN_only_content_is_kept(String html, String expectedHtml) {
-        PolicyImpl policy = new PolicyImpl(Collections.emptyMap(), new WorkspaceCfg());
+    public void GIVEN_minimal_configuration_WHEN_sanitizing_THEN_only_content_is_kept(String html, String expectedHtml) {
+        WorkspaceCfg workspace = new WorkspaceCfg();
+        workspace.setStrategy(WorkspaceCfg.StrategyCfg.SANITIZE);
+        workspace.setAllowedRuleSet(new RuleSetCfg());
+        workspace.getAllowedRuleSet().setElements(of(
+                buildElement(of("basicTag"), null, null)
+        ));
+        PolicyImpl policy = new PolicyImpl(Collections.emptyMap(), workspace);
 
         String sanitized = policy.sanitize(html);
 
@@ -109,8 +168,15 @@ public class PolicyImplTest {
     }
 
     @Test
-    public void GIVEN_empty_configuration_WHEN_validating_THEN_tags_and_attributes_are_rejected() {
-        PolicyImpl policy = new PolicyImpl(Collections.emptyMap(), new WorkspaceCfg());
+    public void GIVEN_minimal_configuration_WHEN_validating_THEN_tags_and_attributes_are_rejected() {
+        WorkspaceCfg workspace = new WorkspaceCfg();
+        workspace.setStrategy(WorkspaceCfg.StrategyCfg.SANITIZE);
+        workspace.setAllowedRuleSet(new RuleSetCfg());
+        workspace.getAllowedRuleSet().setElements(of(
+                buildElement(of("basicTag"), null, null)
+        ));
+
+        PolicyImpl policy = new PolicyImpl(Collections.emptyMap(), workspace);
         String html = "<p>Hello World</p><script>alert('Javascript')</script>";
 
         HtmlValidationResult validationResult = policy.validate(html);

--- a/src/test/java/org/jahia/modules/htmlfiltering/impl/PolicyImplTest.java
+++ b/src/test/java/org/jahia/modules/htmlfiltering/impl/PolicyImplTest.java
@@ -84,6 +84,7 @@ public class PolicyImplTest {
     @Test
     public void GIVEN_element_without_attributes_and_tags_WHEN_creating_policy_THEN_exception_is_thrown() {
         WorkspaceCfg workspace = new WorkspaceCfg();
+        workspace.setStrategy(WorkspaceCfg.StrategyCfg.REJECT);
         RuleSetCfg allowedRuleSet = new RuleSetCfg();
         ElementCfg element = new ElementCfg();
         element.setTags(Collections.emptyList()); // no tags
@@ -99,6 +100,7 @@ public class PolicyImplTest {
     @Test
     public void GIVEN_element_with_tags_and_format_WHEN_creating_policy_THEN_exception_is_thrown() {
         WorkspaceCfg workspace = new WorkspaceCfg();
+        workspace.setStrategy(WorkspaceCfg.StrategyCfg.SANITIZE);
         RuleSetCfg allowedRuleSet = new RuleSetCfg();
         workspace.setAllowedRuleSet(allowedRuleSet);
         ElementCfg element = new ElementCfg();
@@ -115,6 +117,7 @@ public class PolicyImplTest {
     @Test
     public void GIVEN_the_use_of_format_not_defined_WHEN_creating_policy_THEN_exception_is_thrown() {
         WorkspaceCfg workspace = new WorkspaceCfg();
+        workspace.setStrategy(WorkspaceCfg.StrategyCfg.SANITIZE);
         RuleSetCfg allowedRuleSet = new RuleSetCfg();
         workspace.setAllowedRuleSet(allowedRuleSet);
         allowedRuleSet.setElements(of(
@@ -204,6 +207,7 @@ public class PolicyImplTest {
     })
     public void GIVEN_configuration_with_allowed_tags_without_attributes_WHEN_sanitizing_THEN_string_is_sanitized(String html, String expectedHtml) {
         WorkspaceCfg workspace = new WorkspaceCfg();
+        workspace.setStrategy(WorkspaceCfg.StrategyCfg.SANITIZE);
         RuleSetCfg allowedRuleSet = new RuleSetCfg();
         workspace.setAllowedRuleSet(allowedRuleSet);
         allowedRuleSet.setElements(of(
@@ -227,6 +231,7 @@ public class PolicyImplTest {
     })
     public void GIVEN_configuration_with_allowed_attributes_on_tags_WHEN_sanitizing_THEN_string_is_sanitized(String html, String expectedHtml) {
         WorkspaceCfg workspace = new WorkspaceCfg();
+        workspace.setStrategy(WorkspaceCfg.StrategyCfg.SANITIZE);
         RuleSetCfg allowedRuleSet = new RuleSetCfg();
         workspace.setAllowedRuleSet(allowedRuleSet);
         allowedRuleSet.setElements(of(
@@ -251,6 +256,7 @@ public class PolicyImplTest {
     })
     public void GIVEN_configuration_with_allowed_attributes_and_allowed_tags_WHEN_sanitizing_THEN_string_is_sanitized(String html, String expectedHtml) {
         WorkspaceCfg workspace = new WorkspaceCfg();
+        workspace.setStrategy(WorkspaceCfg.StrategyCfg.SANITIZE);
         RuleSetCfg allowedRuleSet = new RuleSetCfg();
         workspace.setAllowedRuleSet(allowedRuleSet);
         allowedRuleSet.setElements(of(
@@ -276,6 +282,7 @@ public class PolicyImplTest {
     })
     public void GIVEN_configuration_with_allowed_protocols_on_a_tags_WHEN_sanitizing_THEN_string_is_sanitized(String html, String expectedHtml) {
         WorkspaceCfg workspace = new WorkspaceCfg();
+        workspace.setStrategy(WorkspaceCfg.StrategyCfg.SANITIZE);
         RuleSetCfg allowedRuleSet = new RuleSetCfg();
         allowedRuleSet.setProtocols(of("http", "https"));
         workspace.setAllowedRuleSet(allowedRuleSet);
@@ -307,6 +314,7 @@ public class PolicyImplTest {
     })
     public void GIVEN_configuration_with_formats_defined_WHEN_sanitizing_THEN_string_is_sanitized_with_the_format(String html, String expectedHtml) {
         WorkspaceCfg workspace = new WorkspaceCfg();
+        workspace.setStrategy(WorkspaceCfg.StrategyCfg.SANITIZE);
         RuleSetCfg allowedRuleSet = new RuleSetCfg();
         allowedRuleSet.setElements(of(
                 buildElement(of("p"), of("id"), "LOWERCASE_LETTERS"),
@@ -354,6 +362,7 @@ public class PolicyImplTest {
 
     private static PolicyImpl buildCompletePolicy() {
         WorkspaceCfg workspace = new WorkspaceCfg();
+        workspace.setStrategy(WorkspaceCfg.StrategyCfg.REJECT);
         RuleSetCfg allowedRuleSet = new RuleSetCfg();
         allowedRuleSet.setElements(of(
                 // accept attributes globally

--- a/tests/cypress/fixtures/configs/configurationStrategy/org.jahia.modules.htmlfiltering-otherSite.yml
+++ b/tests/cypress/fixtures/configs/configurationStrategy/org.jahia.modules.htmlfiltering-otherSite.yml
@@ -4,3 +4,8 @@ htmlFiltering:
     allowedRuleSet:
       elements:
         - tags: [p, h1]
+  liveWorkspace:
+    strategy: SANITIZE
+    allowedRuleSet:
+      elements:
+        - tags: [p, h1]

--- a/tests/cypress/fixtures/configs/configurationStrategy/org.jahia.modules.htmlfiltering-testHtmlFilteringConfigurationStrategy.yml
+++ b/tests/cypress/fixtures/configs/configurationStrategy/org.jahia.modules.htmlfiltering-testHtmlFilteringConfigurationStrategy.yml
@@ -4,3 +4,8 @@ htmlFiltering:
     allowedRuleSet:
       elements:
         - tags: [p, h1]
+  liveWorkspace:
+    strategy: SANITIZE
+    allowedRuleSet:
+      elements:
+        - tags: [p, h1]

--- a/tests/cypress/fixtures/configs/configurationStrategy/org.jahia.modules.htmlfiltering.default.yml
+++ b/tests/cypress/fixtures/configs/configurationStrategy/org.jahia.modules.htmlfiltering.default.yml
@@ -5,3 +5,9 @@ htmlFiltering:
       elements:
         - attributes: [id]
         - tags: [p]
+  liveWorkspace:
+    strategy: SANITIZE
+    allowedRuleSet:
+      elements:
+        - attributes: [id]
+        - tags: [p]


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

Ensure the configuration files have their settings explicitly defined and throw an exception when it's not the case.
There is no default value anymore (for instance the default _SANITIZE_ strategy).

