### PR TITLE
fix: avoid jahia log each time a node is saved

### DIFF
--- a/src/main/java/org/jahia/modules/htmlfiltering/validation/HtmlFilteringValidator.java
+++ b/src/main/java/org/jahia/modules/htmlfiltering/validation/HtmlFilteringValidator.java
@@ -14,7 +14,7 @@ public class HtmlFilteringValidator implements JCRNodeValidator {
     private final JCRNodeWrapper node;
 
     public HtmlFilteringValidator(JCRNodeWrapper node) {
-        logger.info("Creating HtmlFilteringValidator for {}", node.getPath());
+        logger.debug("Creating HtmlFilteringValidator for {}", node.getPath());
         this.node = node;
     }
 


### PR DESCRIPTION
Small fix to avoid this log each time a content is saved:

```
2025-05-22 05:13:07,842: INFO [HtmlFilteringValidator] - Creating HtmlFilteringValidator for /sites/systemsite/contents/rich-text
2025-05-22 05:13:08,494: INFO [HtmlFilteringValidator] - Creating HtmlFilteringValidator for /sites/systemsite/contents/rich-text
2025-05-22 05:13:08,752: INFO [HtmlFilteringValidator] - Creating HtmlFilteringValidator for /sites/systemsite/contents/rich-text
2025-05-22 05:13:08,907: INFO [HtmlFilteringValidator] - Creating HtmlFilteringValidator for /sites/systemsite/contents/rich-text
2025-05-22 05:13:09,152: INFO [HtmlFilteringValidator] - Creating HtmlFilteringValidator for /sites/systemsite/contents/rich-text
```
