### PR TITLE
ci(tests): Fix missing test module in provisioning files

### DIFF
--- a/tests/provisioning-manifest-snapshot-jahia-8.1.7.0.yml
+++ b/tests/provisioning-manifest-snapshot-jahia-8.1.7.0.yml
@@ -3,6 +3,7 @@
 
 - installBundle:
     - 'mvn:org.jahia.modules/html-filtering'
+    - 'mvn:org.jahia.test/html-filtering-test-module'
   autoStart: true
   uninstallPreviousVersion: true
 - karafCommand: "bundle:list"

--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -3,6 +3,7 @@
 
 - installBundle:
     - 'mvn:org.jahia.modules/html-filtering'
+    - 'mvn:org.jahia.test/html-filtering-test-module'
   autoStart: true
   uninstallPreviousVersion: true
 - karafCommand: "bundle:list"


### PR DESCRIPTION
The new [test-module](https://github.com/Jahia/html-filtering/tree/main/tests/jahia-module) is missing from the provisioning files used for the nightly runs, that are currently failing (see [this example](https://github.com/Jahia/html-filtering/actions/runs/15176328221)).