### PR TITLE
ci: added incident services per integration tests run

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,9 +15,10 @@ jobs:
         env:
           - jahia-image: jahia-ee-dev:8-SNAPSHOT
             provisioning: provisioning-manifest-snapshot.yml
+            pagerduty-incident-service: html-filtering-JahiaSN
           - jahia-image: jahia-ee:8.1.7.0
             provisioning: provisioning-manifest-snapshot-jahia-8.1.7.0.yml
-
+            pagerduty-incident-service: html-filtering-Jahia8170
     timeout-minutes: 120
     steps:
       - uses: jahia/jahia-modules-action/helper@v2
@@ -49,7 +50,7 @@ jobs:
           testrail_username: ${{ secrets.TESTRAIL_USERNAME }}
           testrail_password: ${{ secrets.TESTRAIL_PASSWORD }}
           tests_report_name: Nightly test report (Standalone)
-          incident_service: html-filtering
+          incident_service: ${{ matrix.env.pagerduty-incident-service }}
           incident_pagerduty_api_key: ${{ secrets.INCIDENT_PAGERDUTY_API_KEY }}
           incident_pagerduty_reporter_email: ${{ secrets.INCIDENT_PAGERDUTY_REPORTER_EMAIL }}
           incident_pagerduty_reporter_id: ${{ secrets.INCIDENT_PAGERDUTY_REPORTER_ID }}


### PR DESCRIPTION
This makes it possible to collect the overview of all previous executions, per run, on the usual google spreadsheet: https://docs.google.com/spreadsheets/d/1pkU_t_wrdeIXnQAwnExHtu81cZUfH2HIZKOrDCKbolg/edit?gid=0#gid=0

Splitting snapshot vs. releases can be useful when trying to get an overall sense of impact of an issue.