### PR TITLE
test: Fix cleanup after the test ran

### DIFF
--- a/tests/cypress/e2e/configurationStrategy.cy.ts
+++ b/tests/cypress/e2e/configurationStrategy.cy.ts
@@ -114,7 +114,6 @@ describe('Test the configuration strategy used by the HTML filtering module', ()
             expect(value).to.be.equal(EXPECTED_HTML_TEXT_WITH_GLOBAL_DEFAULT);
         });
 
-        removeSiteConfig(OTHER_SITE);
-        removeGlobalCustomConfig();
+        removeSiteConfig(SITE_KEY);
     });
 });


### PR DESCRIPTION
Fix the cleanup operation after a test that is not correctly removing the configuration file being installed, caused by https://github.com/Jahia/html-filtering/pull/111.

This seems to have introduced some flakiness in the tests: https://github.com/Jahia/html-filtering/actions/runs/15273012243/attempts/1, https://github.com/Jahia/html-filtering/actions/runs/15271497107/attempts/1?pr=112 or https://github.com/Jahia/html-filtering/actions/runs/15271497107?pr=112.