### PR TITLE
feat: introduce skipOnPermissions configuration

### DIFF
--- a/src/main/java/org/jahia/modules/htmlfiltering/impl/ConfigBuilder.java
+++ b/src/main/java/org/jahia/modules/htmlfiltering/impl/ConfigBuilder.java
@@ -110,6 +110,7 @@ public class ConfigBuilder {
         return new PolicyImpl(readStrategy(policyModel),
                 createPropsByNodeType(policyModel.getProcess(), "process"),
                 createPropsByNodeType(policyModel.getSkip(), "skip"),
+                policyModel.getSkipOnPermissions() != null ? policyModel.getSkipOnPermissions() : Collections.emptyList(),
                 builder.toFactory());
     }
 

--- a/src/main/java/org/jahia/modules/htmlfiltering/impl/PolicyImpl.java
+++ b/src/main/java/org/jahia/modules/htmlfiltering/impl/PolicyImpl.java
@@ -78,7 +78,8 @@ public final class PolicyImpl implements Policy {
 
     @Override
     public boolean isApplicableToProperty(JCRNodeWrapper node, String propertyName, ExtendedPropertyDefinition propertyDefinition) {
-        boolean result = isRichTextStringProperty(propertyDefinition)
+        boolean result = skipOnPermissions.stream().noneMatch(node::hasPermission) &&
+                isRichTextStringProperty(propertyDefinition)
                 && isPropertyConfigured(node, propertyName, propsToProcessByNodeType)
                 && !isPropertyConfigured(node, propertyName, propsToSkipByNodeType);
 

--- a/src/main/java/org/jahia/modules/htmlfiltering/impl/PolicyImpl.java
+++ b/src/main/java/org/jahia/modules/htmlfiltering/impl/PolicyImpl.java
@@ -27,10 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.jcr.*;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Implementation of the {@link Policy} interface for defining HTML filtering policies
@@ -58,12 +55,19 @@ public final class PolicyImpl implements Policy {
      * The value can be <code>null</code> in case all properties of the node type are to be skipped.
      */
     final Map<String, Set<String>> propsToSkipByNodeType;
+    /**
+     * A list of permissions that, if current user has one of them, will cause the policy to be skipped.
+     * This is useful for cases where certain permissions should bypass the HTML filtering policy.
+     */
+    final List<String> skipOnPermissions;
     private final PolicyFactory policyFactory;
 
-    public PolicyImpl(Strategy strategy, Map<String, Set<String>> propsToProcessByNodeType, Map<String, Set<String>> propsToSkipByNodeType, PolicyFactory policyFactory) {
+    public PolicyImpl(Strategy strategy, Map<String, Set<String>> propsToProcessByNodeType, Map<String, Set<String>> propsToSkipByNodeType,
+                      List<String> skipOnPermissions, PolicyFactory policyFactory) {
         this.strategy = strategy;
         this.propsToProcessByNodeType = propsToProcessByNodeType;
         this.propsToSkipByNodeType = propsToSkipByNodeType;
+        this.skipOnPermissions = skipOnPermissions;
         this.policyFactory = policyFactory;
     }
 

--- a/src/main/java/org/jahia/modules/htmlfiltering/model/PolicyModel.java
+++ b/src/main/java/org/jahia/modules/htmlfiltering/model/PolicyModel.java
@@ -16,6 +16,7 @@
 package org.jahia.modules.htmlfiltering.model;
 
 import org.jahia.modules.htmlfiltering.interceptor.HtmlFilteringInterceptor;
+import org.jahia.modules.htmlfiltering.validation.HtmlFilteringValidator;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.content.nodetypes.ExtendedPropertyDefinition;
 
@@ -29,6 +30,7 @@ public class PolicyModel {
     private PolicyStrategy strategy;
     private List<String> process;
     private List<String> skip;
+    private List<String> skipOnPermissions;
 
     public RuleSetModel getAllowedRuleSet() {
         return allowedRuleSet;
@@ -70,6 +72,14 @@ public class PolicyModel {
         this.skip = skip;
     }
 
+    public List<String> getSkipOnPermissions() {
+        return skipOnPermissions;
+    }
+
+    public void setSkipOnPermissions(List<String> skipOnPermissions) {
+        this.skipOnPermissions = skipOnPermissions;
+    }
+
     /**
      * Defines the strategy for handling HTML content that does not adhere
      * to the allowed rule set.
@@ -79,7 +89,7 @@ public class PolicyModel {
          * Strategy to reject HTML content that does not adhere to the allowed rule set.
          * Any content that violates the defined rules will be deemed invalid and not accepted.
          *
-         * @see org.jahia.modules.htmlfiltering.validation.HtmlValidator#isValid(JCRNodeWrapper, ConstraintValidatorContext)
+         * @see org.jahia.modules.htmlfiltering.validation.HtmlValidator#isValid(HtmlFilteringValidator, ConstraintValidatorContext)
          */
         REJECT,
         /**

--- a/src/main/resources/META-INF/configurations/org.jahia.modules.htmlfiltering.global.default.yml
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.htmlfiltering.global.default.yml
@@ -6,6 +6,7 @@ htmlFiltering:
     LINKS_URL: '(?:(?:[\p{L}\p{N}\\\.#@$%\+&;\-_~,\?=/!{}:]+|#(\w)+)|(\s*(?:(?:ht|f)tps?://|mailto:)[\p{L}\p{N}][\p{L}\p{N}\p{Zs}\.#@$%\+&:\-_~,\?=/!\(\)]*+\s*))'
   editWorkspace:
     strategy: SANITIZE
+    skipOnPermissions: []
     process: ['nt:base.*']
     allowedRuleSet:
       elements:
@@ -63,6 +64,7 @@ htmlFiltering:
       protocols: [http, https, mailto]
   liveWorkspace:
     strategy: SANITIZE
+    skipOnPermissions: []
     process: ['nt:base.*']
     allowedRuleSet:
       elements:

--- a/tests/cypress/e2e/skipOnPermissions.cy.ts
+++ b/tests/cypress/e2e/skipOnPermissions.cy.ts
@@ -6,7 +6,6 @@ describe('Test the skipOnPermissions configuration', () => {
     const ORIGINAL_HTML_TEXT = '<h1 id="myid">my title</h1><h2>sub-title</h2><p class="myClass">my text</p>';
     const SANITIZED_HTML_TEXT = '<h1>my title</h1>sub-title<p>my text</p>'; // Only <h1> and <p> tags are allowed as per the configuration
 
-
     before(() => {
         installConfig(`configs/skipOnPermissions/org.jahia.modules.htmlfiltering.site-${SITE_KEY}.yml`);
         createSite(SITE_KEY, {locale: 'en', serverName: 'localhost', templateSet: 'html-filtering-test-module'});
@@ -21,10 +20,10 @@ describe('Test the skipOnPermissions configuration', () => {
                 }
             ]
         });
-        createUser('billy', 'password')
-        createUser('bob', 'password')
-        grantRoles(`/sites/${SITE_KEY}`, ['editor'], 'bob', 'USER')
-        grantRoles(`/sites/${SITE_KEY}`, ['editor-in-chief'], 'billy', 'USER')
+        createUser('billy', 'password');
+        createUser('bob', 'password');
+        grantRoles(`/sites/${SITE_KEY}`, ['editor'], 'bob', 'USER');
+        grantRoles(`/sites/${SITE_KEY}`, ['editor-in-chief'], 'billy', 'USER');
     });
 
     after(() => {
@@ -34,19 +33,17 @@ describe('Test the skipOnPermissions configuration', () => {
         deleteSite(SITE_KEY);
     });
 
-    it(`When user have the permission HTML-filtering is bypassed`, () => {
-        // the configuration used for this test is using:
+    it('When user has the permission HTML-filtering bypassed', () => {
+        // The configuration used for this test is using:
         // - skipOnPermissions: ['view-full-wysiwyg-editor']
         // it's a permission that is granted to the editor-in-chief role by default in Jahia.
         // So bob (editor) should not be able to bypass the HTML filtering.
-        mutateNodeTextProperty(`/sites/${SITE_KEY}/home/pagecontent/content`, 'textA', ORIGINAL_HTML_TEXT,
-            'en', cy.apolloClient({username: 'bob', password: 'password'})).then(updatedTextProperty => {
+        mutateNodeTextProperty(`/sites/${SITE_KEY}/home/pagecontent/content`, 'textA', ORIGINAL_HTML_TEXT, 'en', cy.apolloClient({username: 'bob', password: 'password'})).then(updatedTextProperty => {
             expect(updatedTextProperty).to.be.equal(SANITIZED_HTML_TEXT);
         });
 
         // But billy (editor-in-chief) should be able to bypass the HTML filtering.
-        mutateNodeTextProperty(`/sites/${SITE_KEY}/home/pagecontent/content`, 'textA', ORIGINAL_HTML_TEXT,
-            'en', cy.apolloClient({username: 'billy', password: 'password'})).then(updatedTextProperty => {
+        mutateNodeTextProperty(`/sites/${SITE_KEY}/home/pagecontent/content`, 'textA', ORIGINAL_HTML_TEXT, 'en', cy.apolloClient({username: 'billy', password: 'password'})).then(updatedTextProperty => {
             expect(updatedTextProperty).to.be.equal(ORIGINAL_HTML_TEXT);
         });
     });

--- a/tests/cypress/e2e/skipOnPermissions.cy.ts
+++ b/tests/cypress/e2e/skipOnPermissions.cy.ts
@@ -1,0 +1,53 @@
+import {addNode, createSite, createUser, deleteSite, deleteUser, grantRoles} from '@jahia/cypress';
+import {installConfig, mutateNodeTextProperty, removeSiteConfig} from '../fixtures/utils';
+
+describe('Test the skipOnPermissions configuration', () => {
+    const SITE_KEY = 'testSkipOnPermissions';
+    const ORIGINAL_HTML_TEXT = '<h1 id="myid">my title</h1><h2>sub-title</h2><p class="myClass">my text</p>';
+    const SANITIZED_HTML_TEXT = '<h1>my title</h1>sub-title<p>my text</p>'; // Only <h1> and <p> tags are allowed as per the configuration
+
+
+    before(() => {
+        installConfig(`configs/skipOnPermissions/org.jahia.modules.htmlfiltering.site-${SITE_KEY}.yml`);
+        createSite(SITE_KEY, {locale: 'en', serverName: 'localhost', templateSet: 'html-filtering-test-module'});
+        addNode({
+            parentPathOrId: `/sites/${SITE_KEY}/home`,
+            name: 'pagecontent',
+            primaryNodeType: 'jnt:contentList',
+            children: [
+                {
+                    name: 'content',
+                    primaryNodeType: 'htmlFilteringTestModule:testValidation'
+                }
+            ]
+        });
+        createUser('billy', 'password')
+        createUser('bob', 'password')
+        grantRoles(`/sites/${SITE_KEY}`, ['editor'], 'bob', 'USER')
+        grantRoles(`/sites/${SITE_KEY}`, ['editor-in-chief'], 'billy', 'USER')
+    });
+
+    after(() => {
+        removeSiteConfig(SITE_KEY);
+        deleteUser('bob');
+        deleteUser('billy');
+        deleteSite(SITE_KEY);
+    });
+
+    it(`When user have the permission HTML-filtering is bypassed`, () => {
+        // the configuration used for this test is using:
+        // - skipOnPermissions: ['view-full-wysiwyg-editor']
+        // it's a permission that is granted to the editor-in-chief role by default in Jahia.
+        // So bob (editor) should not be able to bypass the HTML filtering.
+        mutateNodeTextProperty(`/sites/${SITE_KEY}/home/pagecontent/content`, 'textA', ORIGINAL_HTML_TEXT,
+            'en', cy.apolloClient({username: 'bob', password: 'password'})).then(updatedTextProperty => {
+            expect(updatedTextProperty).to.be.equal(SANITIZED_HTML_TEXT);
+        });
+
+        // But billy (editor-in-chief) should be able to bypass the HTML filtering.
+        mutateNodeTextProperty(`/sites/${SITE_KEY}/home/pagecontent/content`, 'textA', ORIGINAL_HTML_TEXT,
+            'en', cy.apolloClient({username: 'billy', password: 'password'})).then(updatedTextProperty => {
+            expect(updatedTextProperty).to.be.equal(ORIGINAL_HTML_TEXT);
+        });
+    });
+});

--- a/tests/cypress/fixtures/configs/skipOnPermissions/org.jahia.modules.htmlfiltering.site-testSkipOnPermissions.yml
+++ b/tests/cypress/fixtures/configs/skipOnPermissions/org.jahia.modules.htmlfiltering.site-testSkipOnPermissions.yml
@@ -1,0 +1,15 @@
+htmlFiltering:
+  editWorkspace:
+    strategy: SANITIZE
+    skipOnPermissions: ['view-full-wysiwyg-editor']
+    process: ['nt:base.*']
+    allowedRuleSet:
+      elements:
+        - tags: [p, h1]
+  liveWorkspace:
+    strategy: SANITIZE
+    skipOnPermissions: []
+    process: ['nt:base.*']
+    allowedRuleSet:
+      elements:
+        - tags: [p, h1]

--- a/tests/cypress/fixtures/utils/jcrNode.ts
+++ b/tests/cypress/fixtures/utils/jcrNode.ts
@@ -24,8 +24,9 @@ export const modifyContent = (pathOrId: string, text: string, language: string =
  * @param propertyName name of the property to modify
  * @param text new value of the property
  * @param language language of the property, default to 'en'
+ * @param apolloClient optional Apollo Client instance to use, if not provided the default one will be used
  */
-export const mutateNodeTextProperty = (pathOrId: string, propertyName:string, text: string, language: string = 'en') => {
+export const mutateNodeTextProperty = (pathOrId: string, propertyName:string, text: string, language: string = 'en', apolloClient = undefined) => {
     const modifyNodeGql = gql`
         mutation modifyContent($pathOrId: String!, $propertyName: String!, $text: String!, $language: String!) {
             jcr {
@@ -40,7 +41,8 @@ export const mutateNodeTextProperty = (pathOrId: string, propertyName:string, te
             }
         }
     `;
-    return cy.apollo({
+    const client = apolloClient || cy.apolloClient();
+    return client.apollo({
         mutation: modifyNodeGql,
         variables: {pathOrId, propertyName, text, language}
     }).then(response => {


### PR DESCRIPTION
## Description

Introduce the new configuration option: `skipOnPermissions`
Applying on workspace policy.
It allows users to bypass html-filtering in case the user have one of declared `skipOnPermissions` on the node.

## Tests

The following are included in this PR
- [x] Unit Tests (Most changes _should_ have unit tests)
- [x] Integration Tests

