### PR TITLE
test: Remove locale-specific assertions in unit tests

### DIFF
--- a/src/test/java/org/jahia/modules/htmlfiltering/impl/ConfigBuilderTest.java
+++ b/src/test/java/org/jahia/modules/htmlfiltering/impl/ConfigBuilderTest.java
@@ -8,6 +8,8 @@ import org.jahia.modules.htmlfiltering.impl.config.Config;
 import org.jahia.modules.htmlfiltering.model.ConfigModel;
 import org.jahia.modules.htmlfiltering.model.PolicyModel;
 import org.jahia.modules.htmlfiltering.model.RuleSetModel;
+import org.jahia.modules.htmlfiltering.model.validation.constraints.FormatRequiresAttributes;
+import org.jahia.modules.htmlfiltering.model.validation.constraints.RequiresTagsOrAttributes;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.osgi.service.cm.ConfigurationException;
@@ -470,7 +472,7 @@ public class ConfigBuilderTest {
 
         ValidationConfigurationException exception = assertThrows(ValidationConfigurationException.class, () -> buildFromModel(configModel));
 
-        assertContainsExactValidationError(exception, "editWorkspace.allowedRuleSet.elements[0]", "must contain 'tags' and/or 'attributes'");
+        assertContainsExactValidationError(exception, "editWorkspace.allowedRuleSet.elements[0]", RequiresTagsOrAttributes.class);
     }
 
     @Test
@@ -481,7 +483,7 @@ public class ConfigBuilderTest {
 
         ValidationConfigurationException exception = assertThrows(ValidationConfigurationException.class, () -> buildFromModel(configModel));
 
-        assertContainsExactValidationError(exception, "liveWorkspace.allowedRuleSet.elements[0]", "must contain 'tags' and/or 'attributes'");
+        assertContainsExactValidationError(exception, "liveWorkspace.allowedRuleSet.elements[0]", RequiresTagsOrAttributes.class);
     }
 
     @Test
@@ -496,7 +498,7 @@ public class ConfigBuilderTest {
 
         ValidationConfigurationException exception = assertThrows(ValidationConfigurationException.class, () -> buildFromModel(configModel));
 
-        assertContainsExactValidationError(exception, "editWorkspace.allowedRuleSet.elements[0]", "'format' must be used with 'attributes'"); // add format value pas param
+        assertContainsExactValidationError(exception, "editWorkspace.allowedRuleSet.elements[0]", FormatRequiresAttributes.class);
     }
 
     @Test
@@ -511,7 +513,7 @@ public class ConfigBuilderTest {
 
         ValidationConfigurationException exception = assertThrows(ValidationConfigurationException.class, () -> buildFromModel(configModel));
 
-        assertContainsExactValidationError(exception, "liveWorkspace.allowedRuleSet.elements[0]", "'format' must be used with 'attributes'");
+        assertContainsExactValidationError(exception, "liveWorkspace.allowedRuleSet.elements[0]", FormatRequiresAttributes.class);
     }
 
     @Test
@@ -564,6 +566,6 @@ public class ConfigBuilderTest {
         assertContainsValidationError(exception, "editWorkspace", NotNull.class);
         assertContainsValidationError(exception, "liveWorkspace.strategy", NotNull.class);
         assertContainsValidationError(exception, "liveWorkspace.process", NotEmpty.class);
-        assertContainsValidationError(exception, "liveWorkspace.allowedRuleSet.elements[1]", "'format' must be used with 'attributes'");
+        assertContainsValidationError(exception, "liveWorkspace.allowedRuleSet.elements[1]", FormatRequiresAttributes.class);
     }
 }

--- a/src/test/java/org/jahia/modules/htmlfiltering/impl/ConfigBuilderTest.java
+++ b/src/test/java/org/jahia/modules/htmlfiltering/impl/ConfigBuilderTest.java
@@ -12,6 +12,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.osgi.service.cm.ConfigurationException;
 
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Dictionary;
@@ -57,7 +59,7 @@ public class ConfigBuilderTest {
 
         ValidationConfigurationException exception = assertThrows(ValidationConfigurationException.class, () -> buildFromModel(configModel));
 
-        assertContainsExactValidationError(exception, "editWorkspace", "must not be null");
+        assertContainsExactValidationError(exception, "editWorkspace", NotNull.class);
     }
 
     @Test
@@ -67,7 +69,7 @@ public class ConfigBuilderTest {
 
         ValidationConfigurationException exception = assertThrows(ValidationConfigurationException.class, () -> buildFromModel(configModel));
 
-        assertContainsExactValidationError(exception, "liveWorkspace", "must not be null");
+        assertContainsExactValidationError(exception, "liveWorkspace", NotNull.class);
     }
 
     @Test
@@ -133,7 +135,7 @@ public class ConfigBuilderTest {
 
         ValidationConfigurationException exception = assertThrows(ValidationConfigurationException.class, () -> buildFromModel(configModel));
 
-        assertContainsExactValidationError(exception, "editWorkspace.strategy", "must not be null");
+        assertContainsExactValidationError(exception, "editWorkspace.strategy", NotNull.class);
     }
 
     @Test
@@ -143,7 +145,7 @@ public class ConfigBuilderTest {
 
         ValidationConfigurationException exception = assertThrows(ValidationConfigurationException.class, () -> buildFromModel(configModel));
 
-        assertContainsExactValidationError(exception, "liveWorkspace.strategy", "must not be null");
+        assertContainsExactValidationError(exception, "liveWorkspace.strategy", NotNull.class);
     }
 
 
@@ -185,7 +187,7 @@ public class ConfigBuilderTest {
 
         ValidationConfigurationException exception = assertThrows(ValidationConfigurationException.class, () -> buildFromModel(configModel));
 
-        assertContainsExactValidationError(exception, "editWorkspace.process", "must not be empty");
+        assertContainsExactValidationError(exception, "editWorkspace.process", NotEmpty.class);
     }
 
     @Test
@@ -195,7 +197,7 @@ public class ConfigBuilderTest {
 
         ValidationConfigurationException exception = assertThrows(ValidationConfigurationException.class, () -> buildFromModel(configModel));
 
-        assertContainsExactValidationError(exception, "liveWorkspace.process", "must not be empty");
+        assertContainsExactValidationError(exception, "liveWorkspace.process", NotEmpty.class);
     }
 
     @Test
@@ -205,7 +207,7 @@ public class ConfigBuilderTest {
 
         ValidationConfigurationException exception = assertThrows(ValidationConfigurationException.class, () -> buildFromModel(configModel));
 
-        assertContainsExactValidationError(exception, "editWorkspace.process", "must not be empty");
+        assertContainsExactValidationError(exception, "editWorkspace.process", NotEmpty.class);
     }
 
     @Test
@@ -215,7 +217,7 @@ public class ConfigBuilderTest {
 
         ValidationConfigurationException exception = assertThrows(ValidationConfigurationException.class, () -> buildFromModel(configModel));
 
-        assertContainsExactValidationError(exception, "liveWorkspace.process", "must not be empty");
+        assertContainsExactValidationError(exception, "liveWorkspace.process", NotEmpty.class);
     }
 
     @Test
@@ -225,7 +227,7 @@ public class ConfigBuilderTest {
 
         ValidationConfigurationException exception = assertThrows(ValidationConfigurationException.class, () -> buildFromModel(configModel));
 
-        assertContainsExactValidationError(exception, "editWorkspace.allowedRuleSet", "must not be null");
+        assertContainsExactValidationError(exception, "editWorkspace.allowedRuleSet", NotNull.class);
     }
 
     @Test
@@ -235,7 +237,7 @@ public class ConfigBuilderTest {
 
         ValidationConfigurationException exception = assertThrows(ValidationConfigurationException.class, () -> buildFromModel(configModel));
 
-        assertContainsExactValidationError(exception, "liveWorkspace.allowedRuleSet", "must not be null");
+        assertContainsExactValidationError(exception, "liveWorkspace.allowedRuleSet", NotNull.class);
     }
 
 
@@ -423,7 +425,7 @@ public class ConfigBuilderTest {
 
         ValidationConfigurationException exception = assertThrows(ValidationConfigurationException.class, () -> buildFromModel(configModel));
 
-        assertContainsExactValidationError(exception, "editWorkspace.allowedRuleSet.elements", "must not be empty");
+        assertContainsExactValidationError(exception, "editWorkspace.allowedRuleSet.elements", NotEmpty.class);
     }
 
     @Test
@@ -433,7 +435,7 @@ public class ConfigBuilderTest {
 
         ValidationConfigurationException exception = assertThrows(ValidationConfigurationException.class, () -> buildFromModel(configModel));
 
-        assertContainsExactValidationError(exception, "liveWorkspace.allowedRuleSet.elements", "must not be empty");
+        assertContainsExactValidationError(exception, "liveWorkspace.allowedRuleSet.elements", NotEmpty.class);
     }
 
     @Test
@@ -443,7 +445,7 @@ public class ConfigBuilderTest {
 
         ValidationConfigurationException exception = assertThrows(ValidationConfigurationException.class, () -> buildFromModel(configModel));
 
-        assertContainsExactValidationError(exception, "editWorkspace.allowedRuleSet.elements", "must not be empty");
+        assertContainsExactValidationError(exception, "editWorkspace.allowedRuleSet.elements", NotEmpty.class);
     }
 
     @Test
@@ -453,7 +455,7 @@ public class ConfigBuilderTest {
 
         ValidationConfigurationException exception = assertThrows(ValidationConfigurationException.class, () -> buildFromModel(configModel));
 
-        assertContainsExactValidationError(exception, "liveWorkspace.allowedRuleSet.elements", "must not be empty");
+        assertContainsExactValidationError(exception, "liveWorkspace.allowedRuleSet.elements", NotEmpty.class);
     }
 
     //--------------------------------
@@ -559,9 +561,9 @@ public class ConfigBuilderTest {
 
         assertEquals(5, exception.getViolations().size());
         assertContainsValidationError(exception, "formatDefinitions", "the value for the format definition of 'INVALID_FORMAT' must be a valid regular expression");
-        assertContainsValidationError(exception, "editWorkspace", "must not be null");
-        assertContainsValidationError(exception, "liveWorkspace.strategy", "must not be null");
-        assertContainsValidationError(exception, "liveWorkspace.process", "must not be empty");
+        assertContainsValidationError(exception, "editWorkspace", NotNull.class);
+        assertContainsValidationError(exception, "liveWorkspace.strategy", NotNull.class);
+        assertContainsValidationError(exception, "liveWorkspace.process", NotEmpty.class);
         assertContainsValidationError(exception, "liveWorkspace.allowedRuleSet.elements[1]", "'format' must be used with 'attributes'");
     }
 }


### PR DESCRIPTION
Follows https://github.com/Jahia/html-filtering/pull/114.
Remove the assertions in unit tests around contraints error messages that are locale-specific, to make sure the Maven build passes regardless of the system default locale.