### PR TITLE
fix: i18n constraint error messages are not retrieved

### DIFF
--- a/src/main/java/org/jahia/modules/htmlfiltering/model/validation/constraints/FormatRequiresAttributes.java
+++ b/src/main/java/org/jahia/modules/htmlfiltering/model/validation/constraints/FormatRequiresAttributes.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = FormatRequiresAttributesValidator.class)
 public @interface FormatRequiresAttributes {
-    String message() default "{org.jahia.modules.htmlfiltering.model.validation.constraints.FormatRequiresAttributes.message}";
+    String message() default "'format' must be used with 'attributes'";
 
     Class<?>[] groups() default {};
 

--- a/src/main/java/org/jahia/modules/htmlfiltering/model/validation/constraints/RequiresTagsOrAttributes.java
+++ b/src/main/java/org/jahia/modules/htmlfiltering/model/validation/constraints/RequiresTagsOrAttributes.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = RequiresTagsOrAttributesValidator.class)
 public @interface RequiresTagsOrAttributes {
-    String message() default "{org.jahia.modules.htmlfiltering.model.validation.constraints.RequiresTagsOrAttributes.message}";
+    String message() default "must contain 'tags' and/or 'attributes'";
 
     Class<?>[] groups() default {};
 

--- a/src/main/java/org/jahia/modules/htmlfiltering/model/validation/constraints/ValidFormatReference.java
+++ b/src/main/java/org/jahia/modules/htmlfiltering/model/validation/constraints/ValidFormatReference.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = ValidFormatReferenceValidator.class)
 public @interface ValidFormatReference {
-    String message() default "{org.jahia.modules.htmlfiltering.model.validation.constraints.ValidFormatReference.invalid.message}";
+    String message() default "Format references must be defined in 'formatDefinitions'";
 
     Class<?>[] groups() default {};
 

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -1,3 +1,0 @@
-org.jahia.modules.htmlfiltering.model.validation.constraints.RequiresTagsOrAttributes.message=must contain 'tags' and/or 'attributes'
-org.jahia.modules.htmlfiltering.model.validation.constraints.FormatRequiresAttributes.message='format' must be used with 'attributes'
-org.jahia.modules.htmlfiltering.model.validation.constraints.ValidFormatReference.invalid.message=Format references must be defined in 'formatDefinitions'


### PR DESCRIPTION
Use hard-coded error messages for constraints error messages instead of using the i18n standard for JSR 303 validation.

In OSGi environment, the resource does not seem to be retrieved properly (when it's fine when running unit tests).
As those messages are only used to display error messages in the console, they don't actually need to be translated.

#### Before:
```
Caused by: org.jahia.modules.htmlfiltering.impl.ValidationConfigurationException: null : Invalid configuration: 
 - editWorkspace.allowedRuleSet.elements[0]: {org.jahia.modules.htmlfiltering.model.validation.constraints.RequiresTagsOrAttributes.message}
 - editWorkspace.allowedRuleSet.elements[0]: {org.jahia.modules.htmlfiltering.model.validation.constraints.FormatRequiresAttributes.message}
```

#### After:
```
Caused by: org.jahia.modules.htmlfiltering.impl.ValidationConfigurationException: null : Invalid configuration: 
 - editWorkspace.allowedRuleSet.elements[0]: 'format' must be used with 'attributes'
 - editWorkspace.allowedRuleSet.elements[0]: must contain 'tags' and/or 'attributes'
```