### PR TITLE
fix: Make GraphQL 'html' parameter mandatory

### DIFF
--- a/src/main/java/org/jahia/modules/htmlfiltering/graphql/query/GqlHtmlFilteringQuery.java
+++ b/src/main/java/org/jahia/modules/htmlfiltering/graphql/query/GqlHtmlFilteringQuery.java
@@ -18,6 +18,7 @@ package org.jahia.modules.htmlfiltering.graphql.query;
 import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
+import graphql.annotations.annotationTypes.GraphQLNonNull;
 import org.jahia.modules.graphql.provider.dxm.node.NodeQueryExtensions;
 import org.jahia.modules.graphql.provider.dxm.osgi.annotations.GraphQLOsgiService;
 import org.jahia.modules.htmlfiltering.Policy;
@@ -40,8 +41,11 @@ public class GqlHtmlFilteringQuery {
 
     @GraphQLField
     @GraphQLName("validate")
-    @GraphQLDescription("Validate a given html from a resolved policy from a provided worskpace and site from its OSGi configuration, then returns sanitized HTML, removed tags and attributes")
-    public GqlValidationResult validate(@GraphQLName("html") String html, @GraphQLName("workspace") NodeQueryExtensions.Workspace workspace, @GraphQLName("siteKey") String siteKey) {
+    @GraphQLDescription("Validate or sanitize an HTML string for a given workspace and site. It returns the sanitized HTML string, the potential removed tags/attributes and whether the provided HTML string is safe or not.")
+    public GqlValidationResult validate(@GraphQLName("html") @GraphQLNonNull String html, @GraphQLName("workspace") NodeQueryExtensions.Workspace workspace, @GraphQLName("siteKey") String siteKey) {
+        if (workspace == null) {
+            workspace = NodeQueryExtensions.Workspace.EDIT;
+        }
         Policy policy = registry.resolvePolicy(siteKey, workspace.getValue());
         if (policy != null) {
             return new GqlValidationResult(policy.sanitize(html));

--- a/tests/cypress/fixtures/graphql/endpoints/validate.graphql
+++ b/tests/cypress/fixtures/graphql/endpoints/validate.graphql
@@ -1,4 +1,4 @@
-query HtmlFiltering($html: String!, $workspace: Workspace = EDIT, $siteKey: String) {
+query validate($html: String!, $workspace: Workspace, $siteKey: String) {
     htmlFiltering {
         validate(html: $html, workspace: $workspace, siteKey: $siteKey) {
             removedTags

--- a/tests/cypress/fixtures/utils/graphql.ts
+++ b/tests/cypress/fixtures/utils/graphql.ts
@@ -1,0 +1,16 @@
+/**
+ * Corresponds to the GraphQL endpoint "validate" under "HTMLFilteringQuery". See GqlHtmlFilteringQuery#validate()
+ * @param html the HTML text to validate
+ * @param siteKey the site key
+ * @param workspace the workspace
+ */
+export const graphqlValidate = (html: string | null, siteKey: string = null, workspace: string = null) => {
+    return cy.apollo({
+        queryFile: 'graphql/endpoints/validate.graphql',
+        variables: {
+            html: html,
+            workspace: workspace,
+            siteKey: siteKey
+        }
+    });
+};


### PR DESCRIPTION
Mark the `html` parameter of the `validate` GraphQL endpoint as mandatory, and properly handle the case when the optional `workspace` parameter is not passed (and use the edit/default workspace).

It is now possible to validate a string, without passing a site nor a workspace.