### PR TITLE
test(fix): Use a permission that exists in both 8.1.7 and 8.2

### DIFF
--- a/tests/cypress/e2e/skipOnPermissions.cy.ts
+++ b/tests/cypress/e2e/skipOnPermissions.cy.ts
@@ -41,8 +41,8 @@ describe('Test the skipOnPermissions configuration', () => {
 
     it('When user does not have the permission - HTML-filtering is applied', () => {
         // The configuration used for this test is using:
-        // - skipOnPermissions: ['view-full-wysiwyg-editor']
-        // it's a permission that is granted to the editor-in-chief role by default in Jahia.
+        // - skipOnPermissions: ['publish']
+        // it's a permission granted to the 'editor-in-chief' role by default in Jahia, but not to the 'editor' role.
         // So bob (editor) should not be able to bypass the HTML filtering.
         mutateNodeTextProperty(`/sites/${SITE_KEY}/home/pagecontent/content`, 'textA', ORIGINAL_HTML_TEXT, cy.apolloClient({username: USER_EDITOR, password: PASSWORD}))
             .then(updatedTextProperty => {
@@ -52,8 +52,8 @@ describe('Test the skipOnPermissions configuration', () => {
 
     it('When user has the permission - HTML-filtering bypassed', () => {
         // The configuration used for this test is using:
-        // - skipOnPermissions: ['view-full-wysiwyg-editor']
-        // it's a permission that is granted to the editor-in-chief role by default in Jahia.
+        // - skipOnPermissions: ['publish']
+        // it's a permission granted to the 'editor-in-chief' role by default in Jahia, but not to the 'editor' role.
         // But billy (editor-in-chief) should be able to bypass the HTML filtering.
         mutateNodeTextProperty(`/sites/${SITE_KEY}/home/pagecontent/content`, 'textA', ORIGINAL_HTML_TEXT, cy.apolloClient({username: USER_EDITOR_IN_CHIEF, password: 'password'}))
             .then(updatedTextProperty => {

--- a/tests/cypress/fixtures/configs/skipOnPermissions/org.jahia.modules.htmlfiltering.site-testSkipOnPermissions.yml
+++ b/tests/cypress/fixtures/configs/skipOnPermissions/org.jahia.modules.htmlfiltering.site-testSkipOnPermissions.yml
@@ -1,7 +1,7 @@
 htmlFiltering:
   editWorkspace:
     strategy: SANITIZE
-    skipOnPermissions: ['view-full-wysiwyg-editor']
+    skipOnPermissions: ['publish']
     process: ['nt:base.*']
     allowedRuleSet:
       elements:


### PR DESCRIPTION
Fix an issue with the nightly tests that are failing on a Jahia 8.1.7 (see [here](https://github.com/Jahia/html-filtering/actions/runs/15481077015/job/43586901638) as an example).

The root cause is that on Jahia 8.1.7.x, the permission _view-full-wysiwyg-editor_ used to be present in the `currentSite-access` node for the _Editor_ role, but is no longer present in Jahia 8.2.x (done via https://github.com/Jahia/jahia-private/pull/1788).
The fix is to switch to the permission _publish_ that, for both Jahia 8.1.7.x and 8.2.x), exists for the role _Editor in chief_ and does not for the role _Editor_.

