### PR TITLE
fix(test): Fix assertion of the validation error message

### DIFF
--- a/tests/cypress/e2e/graphql.cy.ts
+++ b/tests/cypress/e2e/graphql.cy.ts
@@ -16,7 +16,7 @@ describe('Graphql test', () => {
             expect(result.graphQLErrors).to.exist;
             expect(result.graphQLErrors).to.have.length(1);
             expect(result.graphQLErrors[0].extensions.classification).to.equal('ValidationError');
-            expect(result.graphQLErrors[0].message).to.include('Variable \'html\' has an invalid value');
+            expect(result.graphQLErrors[0].message).to.include('\'html\'');
         });
     });
 


### PR DESCRIPTION
The error message is different between Jahia 8.1.7.x and Jahia 8.2.x, so loosing the assertion to only check if it contains the variable `"html"` in the error message.
Currently, a nightly test fails: https://github.com/Jahia/html-filtering/actions/runs/15487962056/job/43606838220.