### PR TITLE
ci: added missing secrets to jahia-releases repos

### DIFF
--- a/.github/maven.settings.xml
+++ b/.github/maven.settings.xml
@@ -69,6 +69,11 @@
             <username>${env.NEXUS_USERNAME}</username>
             <password>${env.NEXUS_PASSWORD}</password>
         </server>
+        <server>
+            <id>jahia-releases</id>
+            <username>${env.NEXUS_USERNAME}</username>
+            <password>${env.NEXUS_PASSWORD}</password>
+        </server>
     </servers>
     <pluginGroups>
         <pluginGroup>org.owasp</pluginGroup>


### PR DESCRIPTION
Previous [release attempt failed](https://github.com/Jahia/html-filtering/actions/runs/15578059623/job/43866744135), missing secrets when publishing the release for the test module (such release does not go through a staging repo - whose credentials are present)