### PR TITLE
build: Use Jackson 2.15.0 (CVE-2025-52999)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,10 @@
         <jahia.plugin.version>6.9</jahia.plugin.version>
         <jahia-depends>graphql-dxm-provider</jahia-depends>
         <jahia-module-signature>MCwCFF5VQcL93sSKboxJGN2vLju7Kz1MAhRflHAOlRq/JQoy2378Z4ahzKg7EA==</jahia-module-signature>
+        <!-- overwrite versions of Jackson libraries defined in jahia-parent -->
+        <!-- this fixes https://nvd.nist.gov/vuln/detail/CVE-2025-52999 -->
+        <jackson.core.version>2.15.0</jackson.core.version>
+        <jackson-databind.osgi.version>${jackson.core.version}</jackson-databind.osgi.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
## Description

Use Jackson 2.15.0 to fix vulnerability https://nvd.nist.gov/vuln/detail/CVE-2025-52999 [reported by Sonar analysis](https://github.com/Jahia/html-filtering/actions/runs/16015937340/job/45182480478):
```
Error:  Failed to execute goal org.owasp:dependency-check-maven:12.1.1:aggregate (default-cli) on project html-filtering: 
Error:  
Error:  One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '7.0': 
Error:  
Error:  jackson-core-2.14.2.jar (pkg:maven/com.fasterxml.jackson.core/jackson-core@2.14.2, cpe:2.3:a:fasterxml:jackson-modules-java8:2.14.2:*:*:*:*:*:*:*): CVE-2025-52999(8.699999809265137)
``` 
HTML Filtering will now embed `jackson-core-2.15.0.jar` instead of `jackson-core-14.2.jar`.

Before:
```
% mvn dependency:tree -Dincludes='*jackson*'
...
[INFO] --- dependency:3.8.1:tree (default-cli) @ html-filtering ---
[INFO] org.jahia.modules:html-filtering:bundle:2.1.0-SNAPSHOT
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.14.2:provided
[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.14.2:provided
[INFO] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.14.2:compile
[INFO] \- com.fasterxml.jackson.dataformat:jackson-dataformat-properties:jar:2.14.2:compile
```

After:
```
% mvn dependency:tree -Dincludes='*jackson*'
...
[INFO] --- dependency:3.8.1:tree (default-cli) @ html-filtering ---
[INFO] org.jahia.modules:html-filtering:bundle:2.1.0-SNAPSHOT
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.15.0:provided
[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.15.0:provided
[INFO] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.15.0:compile
[INFO] \- com.fasterxml.jackson.dataformat:jackson-dataformat-properties:jar:2.15.0:compile
```