### PR TITLE
build: Do not embed jackson-core lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,8 @@
                                 <!-- dependencies used at runtime to perform validation, without direct imports: -->
                                 <ignoredUnusedDeclaredDependency>org.ops4j.pax.web:pax-web-jsp</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.hibernate.validator:hibernate-validator</ignoredUnusedDeclaredDependency>
+                                <!-- com.fasterxml.jackson.core is declared as provided, so it's not pulled transitively and embedded in the bundle -->
+                                <ignoredUnusedDeclaredDependency>com.fasterxml.jackson.core:jackson-core</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.core.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-properties</artifactId>
             <!-- use the same version as the Jackson core one -->


### PR DESCRIPTION
## Description

Related to [SECURITY-553](https://support.jahia.com/browse/SECURITY-553) (with [CVE-2025-52999](https://nvd.nist.gov/vuln/detail/CVE-2025-52999)).
Do not embed jackson-core library as it is already provided by Jahia.
The import packages towards `com.fasterxml.jackson.core.*` are no longer optional.

Before:
![image](https://github.com/user-attachments/assets/1cc08728-308b-4dd4-b9ca-4959d1101841)

```
Import-Package
  com.fasterxml.jackson.core             {version=[2.14,3), resolution:=optional}
  com.fasterxml.jackson.core.base        {version=[2.14,3), resolution:=optional}
  com.fasterxml.jackson.core.format      {version=[2.14,3), resolution:=optional}
  com.fasterxml.jackson.core.io          {version=[2.14,3), resolution:=optional}
  com.fasterxml.jackson.core.json        {version=[2.14,3), resolution:=optional}
  com.fasterxml.jackson.core.util        {version=[2.14,3), resolution:=optional}
  com.fasterxml.jackson.databind         {version=[2.14,3)}
  com.fasterxml.jackson.databind.cfg     {version=[2.14,3)}
  com.fasterxml.jackson.dataformat.javaprop {version=[2.14,3), resolution:=optional}
  com.fasterxml.jackson.dataformat.javaprop.impl {version=[2.14,3), resolution:=optional}
  com.fasterxml.jackson.dataformat.javaprop.io {version=[2.14,3), resolution:=optional}
  com.fasterxml.jackson.dataformat.javaprop.util {version=[2.14,3), resolution:=optional}
  graphql.annotations.annotationTypes    {version=[6.5,99)}
  javax.annotation                       {resolution:=optional}
  javax.inject                           {resolution:=optional}
  javax.jcr                              {version=[2.0,3)}
  javax.jcr.nodetype                     {version=[2.0,3)}
  javax.validation                       {version=[2.0,3)}
  javax.validation.constraints           {version=[2.0,3)}
  org.apache.commons.collections         {version=[3.2,4)}
  org.apache.commons.io                  {version=[2.11,3)}
  org.apache.commons.lang3               {version=[3.12,4)}
  org.apache.naming.java                 
  org.jahia.api                          
  org.jahia.defaults.config.spring       
  org.jahia.exceptions                   
  org.jahia.modules.graphql.provider.dxm {version=[2.19,4)}
  org.jahia.modules.graphql.provider.dxm.node {version=[2.19,4)}
  org.jahia.modules.graphql.provider.dxm.osgi.annotations {version=[2.19,4)}
  org.jahia.modules.graphql.provider.dxm.security {version=[2.19,4)}
  org.jahia.modules.htmlfiltering        
  org.jahia.osgi                         
  org.jahia.services                     
  org.jahia.services.content             
  org.jahia.services.content.decorator   
  org.jahia.services.content.decorator.validation 
  org.jahia.services.content.interceptor 
  org.jahia.services.content.nodetypes   
  org.jahia.utils.i18n                   
  org.osgi.framework                     {version=[1.8,2)}
  org.osgi.service.cm                    {version=[1.5,2)}
  org.owasp.shim                         {resolution:=optional}
  org.slf4j                              {version=[1.7,2)}

```

After:
![image](https://github.com/user-attachments/assets/91d57901-6d23-4ce9-8bde-51223fcaebf2)

```
Import-Package
  com.fasterxml.jackson.core             {version=[2.14,3)}
  com.fasterxml.jackson.core.base        {version=[2.14,3)}
  com.fasterxml.jackson.core.format      {version=[2.14,3)}
  com.fasterxml.jackson.core.io          {version=[2.14,3)}
  com.fasterxml.jackson.core.json        {version=[2.14,3)}
  com.fasterxml.jackson.core.util        {version=[2.14,3)}
  com.fasterxml.jackson.databind         {version=[2.14,3)}
  com.fasterxml.jackson.databind.cfg     {version=[2.14,3)}
  com.fasterxml.jackson.dataformat.javaprop {version=[2.14,3), resolution:=optional}
  com.fasterxml.jackson.dataformat.javaprop.impl {version=[2.14,3), resolution:=optional}
  com.fasterxml.jackson.dataformat.javaprop.io {version=[2.14,3), resolution:=optional}
  com.fasterxml.jackson.dataformat.javaprop.util {version=[2.14,3), resolution:=optional}
  graphql.annotations.annotationTypes    {version=[6.5,99)}
  javax.annotation                       {resolution:=optional}
  javax.inject                           {resolution:=optional}
  javax.jcr                              {version=[2.0,3)}
  javax.jcr.nodetype                     {version=[2.0,3)}
  javax.validation                       {version=[2.0,3)}
  javax.validation.constraints           {version=[2.0,3)}
  org.apache.commons.collections         {version=[3.2,4)}
  org.apache.commons.io                  {version=[2.11,3)}
  org.apache.commons.lang3               {version=[3.12,4)}
  org.apache.naming.java                 
  org.jahia.api                          
  org.jahia.defaults.config.spring       
  org.jahia.exceptions                   
  org.jahia.modules.graphql.provider.dxm {version=[2.19,4)}
  org.jahia.modules.graphql.provider.dxm.node {version=[2.19,4)}
  org.jahia.modules.graphql.provider.dxm.osgi.annotations {version=[2.19,4)}
  org.jahia.modules.graphql.provider.dxm.security {version=[2.19,4)}
  org.jahia.modules.htmlfiltering        
  org.jahia.osgi                         
  org.jahia.services                     
  org.jahia.services.content             
  org.jahia.services.content.decorator   
  org.jahia.services.content.decorator.validation 
  org.jahia.services.content.interceptor 
  org.jahia.services.content.nodetypes   
  org.jahia.utils.i18n                   
  org.osgi.framework                     {version=[1.8,2)}
  org.osgi.service.cm                    {version=[1.5,2)}
  org.owasp.shim                         {resolution:=optional}
  org.slf4j                              {version=[1.7,2)}
```
