### PR TITLE
build(deps): Bump owasp-java-html-sanitizer from 20240325.1 to 202601…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
             <artifactId>owasp-java-html-sanitizer</artifactId>
-            <version>20240325.1</version>
+            <version>20260102.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION

## Description

Bump _com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer_ dependency from `20240325.1` to `20260102.1`.

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Includes https://github.com/OWASP/java-html-sanitizer/issues/358 and a fix for [CVE-2025-66021](https://nvd.nist.gov/vuln/detail/CVE-2025-66021), see https://github.com/advisories/GHSA-g9gq-3pfx-2gw2 for more details.

