### PR TITLE
feat!: Switched default edit workspace strategy to "REJECT"

### DIFF
--- a/.chachalog/nMOlp2Ac.md
+++ b/.chachalog/nMOlp2Ac.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+html-filtering: major
+---
+
+Changed the default HTML filtering strategy for the edit workspace from `SANITIZE` to `REJECT` (#170).

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
             <artifactId>owasp-java-html-sanitizer</artifactId>
-            <version>20260313.1</version>
+            <version>20260102.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <properties>
         <jahia.plugin.version>6.9</jahia.plugin.version>
         <jahia-depends>graphql-dxm-provider</jahia-depends>
-        <jahia-module-signature>MCwCFF5VQcL93sSKboxJGN2vLju7Kz1MAhRflHAOlRq/JQoy2378Z4ahzKg7EA==</jahia-module-signature>
+        <jahia-module-signature>MCwCFC1B63uozzN/IRhcAwjNpswyX7bIAhRa5m2PSBB13YR44nP3Vn3QjDENNA==</jahia-module-signature>
     </properties>
 
     <repositories>
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
             <artifactId>owasp-java-html-sanitizer</artifactId>
-            <version>20260102.1</version>
+            <version>20260313.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <artifactId>html-filtering</artifactId>
     <name>Jahia HTML Filtering</name>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This modules provides configuration for HTML filtering.</description>
 

--- a/tests/cypress/e2e/configurationStrategy.cy.ts
+++ b/tests/cypress/e2e/configurationStrategy.cy.ts
@@ -1,5 +1,5 @@
 import {addNode, createSite, deleteSite} from '@jahia/cypress';
-import {getContent, installConfig, modifyContent, removeGlobalCustomConfig, removeSiteConfig} from '../fixtures/utils';
+import {expectHtmlValidationError, getContent, installConfig, modifyContent, removeGlobalCustomConfig, removeSiteConfig} from '../fixtures/utils';
 
 // NB: this is not intended to be a comprehensive tests suite for the sanitization, but rather a quick sanity check
 //     to ensure that the right policy is used for a given site, depending on the configuration in place.
@@ -16,8 +16,9 @@ describe('Test the configuration strategy used by the HTML filtering module', ()
     const CONFIG_OTHER_SITE_PATH = `configs/configurationStrategy/${CONFIG_OTHER_SITE_NAME}`;
     const RICH_TEXT_NODE = 'testRichTextNode';
     const PATH = `/sites/${SITE_KEY}/home/pagecontent/${RICH_TEXT_NODE}`;
-    const HTML_TEXT = '<h1 id="@invalid">my title</h1><p id="abc" class="myClass">my text</p>';
-    const EXPECTED_HTML_TEXT_WITH_GLOBAL_DEFAULT = '<h1>my title</h1><p id="abc" class="myClass">my text</p>';
+    const HTML_TEXT_INVALID = '<h1 id="@invalid">my title</h1><p id="abc" class="myClass">my text</p>';
+    const HTML_TEXT_VALID = '<h1 id="validId">my title</h1><p id="abc" class="myClass">my text</p>';
+    const INVALID_ID_MESSAGE = 'Unauthorized attribute "id" for tag <h1>.';
     const EXPECTED_HTML_TEXT_WITH_GLOBAL_CUSTOM = 'my title<p id="abc">my text</p>';
     const EXPECTED_HTML_TEXT_WITH_PER_SITE = '<h1>my title</h1><p>my text</p>';
 
@@ -49,11 +50,20 @@ describe('Test the configuration strategy used by the HTML filtering module', ()
         removeSiteConfig(OTHER_SITE);
     });
 
-    it('when no configuration is provided, the HTML text is sanitized using the global default strategy', () => {
-        modifyContent(PATH, HTML_TEXT);
+    it('when no configuration is provided, the REJECT strategy should reject invalid HTML', () => {
+        modifyContent(PATH, HTML_TEXT_INVALID).then(result => {
+            expectHtmlValidationError(result, INVALID_ID_MESSAGE);
+        });
         getContent(PATH).then(result => {
             const value = result.data.jcr.nodeByPath.property.value;
-            expect(value).to.be.equal(EXPECTED_HTML_TEXT_WITH_GLOBAL_DEFAULT);
+            expect(value, 'the content should not have been modified').to.be.equal('');
+        });
+    });
+
+    it('when no configuration is provided, valid HTML should be accepted using the global default strategy', () => {
+        modifyContent(PATH, HTML_TEXT_VALID);
+        getContent(PATH).then(result => {
+            expect(result.data.jcr.nodeByPath.property.value).to.be.equal(HTML_TEXT_VALID);
         });
     });
 
@@ -63,7 +73,7 @@ describe('Test the configuration strategy used by the HTML filtering module', ()
         });
 
         cy.step('Modify and validate content', () => {
-            modifyContent(PATH, HTML_TEXT);
+            modifyContent(PATH, HTML_TEXT_INVALID);
             getContent(PATH).then(result => {
                 const value = result.data.jcr.nodeByPath.property.value;
                 expect(value).to.be.equal(EXPECTED_HTML_TEXT_WITH_GLOBAL_CUSTOM);
@@ -77,7 +87,7 @@ describe('Test the configuration strategy used by the HTML filtering module', ()
         });
 
         cy.step('Modify and validate content', () => {
-            modifyContent(PATH, HTML_TEXT);
+            modifyContent(PATH, HTML_TEXT_INVALID);
             getContent(PATH).then(result => {
                 const value = result.data.jcr.nodeByPath.property.value;
                 expect(value).to.be.equal(EXPECTED_HTML_TEXT_WITH_PER_SITE);
@@ -92,7 +102,7 @@ describe('Test the configuration strategy used by the HTML filtering module', ()
         });
 
         cy.step('Modify and validate content', () => {
-            modifyContent(PATH, HTML_TEXT);
+            modifyContent(PATH, HTML_TEXT_INVALID);
             getContent(PATH).then(result => {
                 const value = result.data.jcr.nodeByPath.property.value;
                 expect(value).to.be.equal(EXPECTED_HTML_TEXT_WITH_PER_SITE);
@@ -106,10 +116,9 @@ describe('Test the configuration strategy used by the HTML filtering module', ()
         });
 
         cy.step('Modify and validate content', () => {
-            modifyContent(PATH, HTML_TEXT);
-            getContent(PATH).then(result => {
-                const value = result.data.jcr.nodeByPath.property.value;
-                expect(value).to.be.equal(EXPECTED_HTML_TEXT_WITH_GLOBAL_DEFAULT);
+            modifyContent(PATH, HTML_TEXT_INVALID).then(result => {
+                // With REJECT strategy, this should fail validation
+                expectHtmlValidationError(result);
             });
         });
     });
@@ -121,7 +130,7 @@ describe('Test the configuration strategy used by the HTML filtering module', ()
         });
 
         cy.step('Modify and validate content', () => {
-            modifyContent(PATH, HTML_TEXT);
+            modifyContent(PATH, HTML_TEXT_INVALID);
             getContent(PATH).then(result => {
                 const value = result.data.jcr.nodeByPath.property.value;
                 expect(value).to.be.equal(EXPECTED_HTML_TEXT_WITH_GLOBAL_CUSTOM);
@@ -136,10 +145,9 @@ describe('Test the configuration strategy used by the HTML filtering module', ()
         });
 
         cy.step('Modify and validate content', () => {
-            modifyContent(PATH, HTML_TEXT);
-            getContent(PATH).then(result => {
-                const value = result.data.jcr.nodeByPath.property.value;
-                expect(value).to.be.equal(EXPECTED_HTML_TEXT_WITH_GLOBAL_DEFAULT);
+            modifyContent(PATH, HTML_TEXT_INVALID).then(result => {
+                // With REJECT strategy (global default), this should fail validation
+                expectHtmlValidationError(result);
             });
         });
     });

--- a/tests/cypress/e2e/defaultFiltering.cy.ts
+++ b/tests/cypress/e2e/defaultFiltering.cy.ts
@@ -1,5 +1,5 @@
 import {addNode, createSite, deleteSite} from '@jahia/cypress';
-import {getContent, modifyContent, removeGlobalCustomConfig} from '../fixtures/utils';
+import {expectHtmlValidationError, getContent, modifyContent, removeGlobalCustomConfig} from '../fixtures/utils';
 
 /**
  * Test scenarios for default filtering cases
@@ -47,7 +47,7 @@ describe('Default HTML filtering', () => {
 
     it('allows internal links - content', () => {
         // Note that the actual href text being sent over to the sanitizer is '##cms-context##/{mode}/{lang}/##ref:link1##'
-        const text = `<p><a href="/cms/{mode}/{lang}/sites/${SITE_KEY}/home.html" title="go to home page">home page</a></p>`;
+        const text = `<p><a href="/cms/{mode}/{lang}/sites/${SITE_KEY}/home.html" title="go to home page">home email@address.com page</a></p>`;
         modifyContent(path, text);
         getContent(path).then(result => {
             const value = result.data.jcr.nodeByPath.property.value;
@@ -73,24 +73,15 @@ describe('Default HTML filtering', () => {
 
     it('rejects invalid protocol links', () => {
         const text = '<p>This is an <a href="javascript://%0aalert(document.location)">xss test</a></p>';
-        modifyContent(path, text);
-        getContent(path).then(result => {
-            const value = result.data.jcr.nodeByPath.property.value;
-            expect(value).to.contain('<p>');
-            expect(value).to.not.contain('<a');
-            expect(value).to.not.contain('href');
+        modifyContent(path, text).then(result => {
+            expectHtmlValidationError(result);
         });
     });
 
     it('rejects invalid href links', () => {
         const text = '<p>This is an <a href="#javascript:alert(\'hello\')" target="_blank">xss test</a></p>';
-        modifyContent(path, text);
-        getContent(path).then(result => {
-            const value = result.data.jcr.nodeByPath.property.value;
-            expect(value).to.contain('<p>');
-            expect(value).to.contain('<a');
-            expect(value).to.not.contain('href');
-            expect(value).to.contain('target');
+        modifyContent(path, text).then(result => {
+            expectHtmlValidationError(result);
         });
     });
 });

--- a/tests/cypress/e2e/explicitPropertiesDeclaration.cy.ts
+++ b/tests/cypress/e2e/explicitPropertiesDeclaration.cy.ts
@@ -1,5 +1,5 @@
 import {addNode, createSite, deleteSite} from '@jahia/cypress';
-import {getContent, installConfig, modifyContent, removeGlobalCustomConfig, removeSiteConfig, readYAMLConfig, installYAMLConfig} from '../fixtures/utils';
+import {expectHtmlValidationError, getContent, installConfig, modifyContent, removeGlobalCustomConfig, removeSiteConfig, readYAMLConfig, installYAMLConfig} from '../fixtures/utils';
 
 describe('Test explicit properties declaration', () => {
     const SPEC_NAME = Cypress.spec.name.split('.')[0];
@@ -24,12 +24,22 @@ describe('Test explicit properties declaration', () => {
     const HTML_TEXT = '<h1 id="@invalid">H1 Header</h1> | <p id="abc" class="myClass">my text</p><script>alert(document.location)</script>';
     const EXPECTED_HTML_TEXT_WITH_PER_SITE = '<h1>H1 Header</h1> | <p class="myClass">my text</p>';
     const EXPECTED_HTML_TEXT_WITH_GLOBAL_CUSTOM = 'H1 Header | <p id="abc">my text</p>';
-    const EXPECTED_HTML_TEXT_WITH_GLOBAL_DEFAULT = '<h1>H1 Header</h1> | <p id="abc" class="myClass">my text</p>';
 
     const modifyAndValidate = (path: string, htmlText: string, expectedHtmlText: string) => {
         modifyContent(path, htmlText);
         getContent(path).then(result => {
             expect(result.data.jcr.nodeByPath.property.value).to.be.equal(expectedHtmlText);
+        });
+    };
+
+    /**
+     * Verifies that the global default REJECT strategy is active: submitting the invalid HTML_TEXT
+     * must produce a validation error, proving that the (invalid) site config was ignored and the
+     * global default was applied instead.
+     */
+    const modifyAndExpectRejection = (path: string) => {
+        modifyContent(path, HTML_TEXT).then(result => {
+            expectHtmlValidationError(result);
         });
     };
 
@@ -79,8 +89,8 @@ describe('Test explicit properties declaration', () => {
                 });
             });
 
-            cy.step('Modify RichText content and make sure global.default config is applied', () => {
-                modifyAndValidate(SITES[0].NODE_PATH, HTML_TEXT, EXPECTED_HTML_TEXT_WITH_GLOBAL_DEFAULT);
+            cy.step('Modify RichText content and make sure global.default REJECT strategy is applied', () => {
+                modifyAndExpectRejection(SITES[0].NODE_PATH);
             });
         });
 
@@ -93,8 +103,8 @@ describe('Test explicit properties declaration', () => {
                 });
             });
 
-            cy.step('Modify RichText content and make sure global.default config is applied', () => {
-                modifyAndValidate(SITES[0].NODE_PATH, HTML_TEXT, EXPECTED_HTML_TEXT_WITH_GLOBAL_DEFAULT);
+            cy.step('Modify RichText content and make sure global.default REJECT strategy is applied', () => {
+                modifyAndExpectRejection(SITES[0].NODE_PATH);
             });
         });
 
@@ -106,8 +116,8 @@ describe('Test explicit properties declaration', () => {
                 });
             });
 
-            cy.step('Modify RichText content and make sure global.default config is applied', () => {
-                modifyAndValidate(SITES[0].NODE_PATH, HTML_TEXT, EXPECTED_HTML_TEXT_WITH_GLOBAL_DEFAULT);
+            cy.step('Modify RichText content and make sure global.default REJECT strategy is applied', () => {
+                modifyAndExpectRejection(SITES[0].NODE_PATH);
             });
         });
 
@@ -119,8 +129,8 @@ describe('Test explicit properties declaration', () => {
                 });
             });
 
-            cy.step('Modify RichText content and make sure global.default config is applied', () => {
-                modifyAndValidate(SITES[0].NODE_PATH, HTML_TEXT, EXPECTED_HTML_TEXT_WITH_GLOBAL_DEFAULT);
+            cy.step('Modify RichText content and make sure global.default REJECT strategy is applied', () => {
+                modifyAndExpectRejection(SITES[0].NODE_PATH);
             });
         });
 
@@ -132,8 +142,8 @@ describe('Test explicit properties declaration', () => {
                 });
             });
 
-            cy.step('Modify RichText content and make sure global.default config is applied', () => {
-                modifyAndValidate(SITES[0].NODE_PATH, HTML_TEXT, EXPECTED_HTML_TEXT_WITH_GLOBAL_DEFAULT);
+            cy.step('Modify RichText content and make sure global.default REJECT strategy is applied', () => {
+                modifyAndExpectRejection(SITES[0].NODE_PATH);
             });
         });
 
@@ -145,8 +155,8 @@ describe('Test explicit properties declaration', () => {
                 });
             });
 
-            cy.step('Modify RichText content and make sure global.default config is applied', () => {
-                modifyAndValidate(SITES[0].NODE_PATH, HTML_TEXT, EXPECTED_HTML_TEXT_WITH_GLOBAL_DEFAULT);
+            cy.step('Modify RichText content and make sure global.default REJECT strategy is applied', () => {
+                modifyAndExpectRejection(SITES[0].NODE_PATH);
             });
         });
 
@@ -158,8 +168,8 @@ describe('Test explicit properties declaration', () => {
                 });
             });
 
-            cy.step('Modify RichText content and make sure global.default config is applied', () => {
-                modifyAndValidate(SITES[0].NODE_PATH, HTML_TEXT, EXPECTED_HTML_TEXT_WITH_GLOBAL_DEFAULT);
+            cy.step('Modify RichText content and make sure global.default REJECT strategy is applied', () => {
+                modifyAndExpectRejection(SITES[0].NODE_PATH);
             });
         });
     });
@@ -281,12 +291,12 @@ describe('Test explicit properties declaration', () => {
                 });
             });
 
-            cy.step('Modify RichText content in site-1 and make sure global.default config is applied', () => {
-                modifyAndValidate(SITES[0].NODE_PATH, HTML_TEXT, EXPECTED_HTML_TEXT_WITH_GLOBAL_DEFAULT);
+            cy.step('Modify RichText content in site-1 and make sure global.default REJECT strategy is applied', () => {
+                modifyAndExpectRejection(SITES[0].NODE_PATH);
             });
 
-            cy.step('Modify RichText content in site-2 and make sure global.default config is applied', () => {
-                modifyAndValidate(SITES[1].NODE_PATH, HTML_TEXT, EXPECTED_HTML_TEXT_WITH_GLOBAL_DEFAULT);
+            cy.step('Modify RichText content in site-2 and make sure global.default REJECT strategy is applied', () => {
+                modifyAndExpectRejection(SITES[1].NODE_PATH);
             });
         });
 

--- a/tests/cypress/e2e/globalDefaultConfiguration.cy.ts
+++ b/tests/cypress/e2e/globalDefaultConfiguration.cy.ts
@@ -1,5 +1,5 @@
 import {addNode, createSite, deleteSite} from '@jahia/cypress';
-import {mutateNodeProperty} from '../fixtures/utils';
+import {expectHtmlValidationError, mutateNodeProperty} from '../fixtures/utils';
 
 /**
  * Test scenarios for the global default configuration (org.jahia.modules.htmlfiltering.global.default.yml).
@@ -93,7 +93,9 @@ describe('Test global default configuration', () => {
     invalidIdValues.forEach(value => {
         it(`"${value}" is not a valid value for the 'id' attribute`, () => {
             const text = `<div id="${value}">sample</div>`;
-            modifyAndCheck(text, '<div>sample</div>');
+            mutateNodeProperty(PATH, 'prop', text).then(response => {
+                expectHtmlValidationError(response);
+            });
         });
     });
 
@@ -113,12 +115,15 @@ describe('Test global default configuration', () => {
     inlineFormattingTagsRemovedIfEmpty.forEach(tag => {
         it(`inline formatting tag "${tag}" is removed if it has not attribute, kept otherwise`, () => {
             const text = `<${tag}>no attribute</${tag}><${tag} id="myid">with id</${tag}>`;
-            modifyAndCheck(text, `no attribute<${tag} id="myid">with id</${tag}>`);
+            mutateNodeProperty(PATH, 'prop', text).then(response => {
+                expectHtmlValidationError(response);
+            });
         });
     });
-    it('inline formatting line breaks <br> tag is allowed and formatted', () => {
+    it('inline formatting line breaks <br> tag is allowed', () => {
         const text = '<p>text<br>with<br/>line<br />breaks</p>';
-        modifyAndCheck(text, '<p>text<br />with<br />line<br />breaks</p>');
+        // With REJECT strategy the content is stored as-is (no normalization); all <br> variants are accepted
+        modifyAndCheck(text);
     });
 
     // --------
@@ -226,24 +231,20 @@ describe('Test global default configuration', () => {
     // href links on <a> :
     // -------------------
 
-    const allowedHrefOnA = [{input: '/path/of/link.html', expected: '/path/of/link.html'}, {
-        input: 'http://sample.link',
-        expected: 'http://sample.link'
-    }, {input: 'https://sample.link', expected: 'https://sample.link'}, {
-        input: 'mailto:johndoe@gmail.com',
-        expected: 'mailto:johndoe&#64;gmail.com'
-    }, {
-        input: 'https://sample.com/sub/path/asset.pdf',
-        expected: 'https://sample.com/sub/path/asset.pdf'
-    }, {
-        input: 'http://mywebsite.io/mypage.html?p1=v1&p2=v2',
-        expected: 'http://mywebsite.io/mypage.html?p1&#61;v1&amp;p2&#61;v2'
-    }];
+    // Note: with REJECT strategy the content is stored as-is (no character encoding by the sanitizer).
+    // The encoding behavior (e.g. @ -> &#64;) is tested separately in globalDefaultSanitizeStrategy.cy.ts.
+    const allowedHrefOnA = [
+        '/path/of/link.html',
+        'http://sample.link',
+        'https://sample.link',
+        'mailto:johndoe@gmail.com',
+        'https://sample.com/sub/path/asset.pdf',
+        'http://mywebsite.io/mypage.html?p1=v1&p2=v2'
+    ];
     allowedHrefOnA.forEach(link => {
-        it(`"${link.input}" is allowed as a[href]`, () => {
-            const text = `<a href="${link.input}">sample</a>`;
-            const expected = `<a href="${link.expected}">sample</a>`;
-            modifyAndCheck(text, expected);
+        it(`"${link}" is allowed as a[href]`, () => {
+            const text = `<a href="${link}">sample</a>`;
+            modifyAndCheck(text);
         });
     });
     // eslint-disable-next-line no-script-url
@@ -251,7 +252,9 @@ describe('Test global default configuration', () => {
     disallowedHrefOnA.forEach(link => {
         it(`"${link}" is not allowed as a[href]`, () => {
             const text = `<a href="${link}">sample</a>`;
-            modifyAndCheck(text, 'sample'); // The whole <a> tag should be removed
+            mutateNodeProperty(PATH, 'prop', text).then(response => {
+                expectHtmlValidationError(response);
+            });
         });
     });
 
@@ -306,37 +309,9 @@ describe('Test global default configuration', () => {
     disallowedMediaLinks.forEach(link => {
         it(`${link} is not an allowed media link`, () => {
             const text = mediaTextForLink(link);
-            const expectedText = `
-    <audio controls="controls" muted="muted">
-      <source type="audio/ogg"/>
-    Your browser does not support the audio element.
-    </audio>
-
-    <img
-      alt="alt text" />
-
-    <video controls="controls" width="250" height="200" muted="muted">
-      <source type="video/webm" />
-    </video>
-
-    <video controls="controls">
-      <track
-        default="default"
-        kind="captions"
-        srclang="en" />
-      Download the
-      MP4
-      video, and
-      subtitles.
-    </video>
-
-    <picture>
-      <source
-        media="(orientation: portrait)" />
-      <img alt="alt text" />
-    </picture>
-    `;
-            modifyAndCheck(text, expectedText);
+            mutateNodeProperty(PATH, 'prop', text).then(response => {
+                expectHtmlValidationError(response);
+            });
         });
     });
 
@@ -345,9 +320,10 @@ describe('Test global default configuration', () => {
     // ----------------------
 
     it('Style attribute is protected against CSS-based attacks while preserving safe styles', () => {
-        const text = `
-    <div style="color: blue; font-size: 14px; margin: 10px; border: 1px solid black;">Safe styling</div>
-    
+        const textSafeStyles = '<div style="color: blue; font-size: 14px; margin: 10px; border: 1px solid black;">Safe styling</div>';
+        modifyAndCheck(textSafeStyles);
+
+        const textDangerousStyles = `
     <div style="background-image: url('https://evil.com/tracking.jpg');">Remote image loading</div>
     <div style="background: url('javascript:alert(1)');">JavaScript URL</div>
     <div style="position: fixed; top: 0; left: 0; z-index: 9999;">Position manipulation</div>
@@ -357,20 +333,8 @@ describe('Test global default configuration', () => {
     <div style="background-image: url(data:image/svg+xml,%3Csvg%20onload%3Dalert(1)%3E%3C/svg%3E);">Data URL with SVG</div>
     <div style="pointer-events: none;">Interaction hijacking</div>
     `;
-
-        const expected = `
-    <div style="color:blue;font-size:14px;margin:10px;border:1px solid black">Safe styling</div>
-    
-    <div>Remote image loading</div>
-    <div>JavaScript URL</div>
-    <div>Position manipulation</div>
-    <div>XBL binding</div>
-    <div>IE behavior</div>
-    <div>CSS expression</div>
-    <div>Data URL with SVG</div>
-    <div>Interaction hijacking</div>
-    `;
-
-        modifyAndCheck(text, expected);
+        mutateNodeProperty(PATH, 'prop', textDangerousStyles).then(response => {
+            expectHtmlValidationError(response);
+        });
     });
 });

--- a/tests/cypress/e2e/globalDefaultSanitizeStrategy.cy.ts
+++ b/tests/cypress/e2e/globalDefaultSanitizeStrategy.cy.ts
@@ -1,0 +1,234 @@
+import {addNode, createSite, deleteSite} from '@jahia/cypress';
+import {installConfig, mutateNodeProperty, removeGlobalCustomConfig} from '../fixtures/utils';
+
+/**
+ * Test scenarios for the SANITIZE strategy behavior on the global default configuration rule set.
+ *
+ * These tests complement globalDefaultConfiguration.cy.ts (which uses the default REJECT strategy)
+ * by verifying how the sanitizer transforms invalid/unsafe HTML when the SANITIZE strategy is active:
+ *   - Invalid attributes are stripped (not rejected)
+ *   - Disallowed tags/protocols result in tag/attribute removal (not a validation error)
+ *   - The sanitizer normalizes and encodes certain characters in attribute values
+ *
+ * The rule set used here mirrors the global default configuration exactly; only the edit workspace
+ * strategy is changed to SANITIZE via a global custom configuration override.
+ */
+describe('Test sanitization behavior of the global default configuration rule set (with SANITIZE strategy)', () => {
+    const SITE_KEY = 'testGlobalDefaultConfigSanitize';
+    const NODE = 'testNode';
+    const PATH = `/sites/${SITE_KEY}/home/pagecontent/${NODE}`;
+    const CONFIG_PATH = 'configs/globalDefaultConfiguration/org.jahia.modules.htmlfiltering.global.custom.yml';
+
+    before(() => {
+        // Install a global custom config with the same rules as the global default, but using SANITIZE strategy
+        installConfig(CONFIG_PATH);
+        createSite(SITE_KEY, {locale: 'en', serverName: 'localhost', templateSet: 'html-filtering-test-module'});
+        addNode({
+            parentPathOrId: `/sites/${SITE_KEY}/home`,
+            name: 'pagecontent',
+            primaryNodeType: 'jnt:contentList',
+            children: [
+                {
+                    name: NODE,
+                    primaryNodeType: 'htmlFilteringTestModule:testGlobalDefaultConfiguration',
+                    properties: [{name: 'prop'}]
+                }
+            ]
+        });
+    });
+
+    after(() => {
+        deleteSite(SITE_KEY);
+        removeGlobalCustomConfig();
+    });
+
+    function modifyAndCheck(text: string, expected = text) {
+        mutateNodeProperty(PATH, 'prop', text).then(response => {
+            const resultNoSpace = response.data.jcr.mutateNode.mutateProperty.property.value.replace(/\s/g, '');
+            const expectedNoSpace = expected.replace(/\s/g, '');
+            expect(resultNoSpace).to.eq(expectedNoSpace);
+        });
+    }
+
+    // --------------
+    // id attribute :
+    // --------------
+
+    const invalidIdValues =
+        [
+            '1header',
+            '9section',
+            '_sidebar',
+            '-menu',
+            ':content',
+            '.title',
+            'header@section',
+            'content/page',
+            'div#main',
+            'form?field',
+            '     spaces not allowed'
+        ];
+    invalidIdValues.forEach(value => {
+        it(`"${value}" is not a valid value for the 'id' attribute - it is removed by the sanitizer`, () => {
+            const text = `<div id="${value}">sample</div>`;
+            modifyAndCheck(text, '<div>sample</div>');
+        });
+    });
+
+    // -------------------
+    // inline formatting :
+    // -------------------
+
+    // List of inline formatting tags are removed if they have no attribute. See HtmlPolicyBuilder#DEFAULT_SKIP_IF_EMPTY for details.
+    const inlineFormattingTagsRemovedIfEmpty = ['font', 'span'];
+    inlineFormattingTagsRemovedIfEmpty.forEach(tag => {
+        it(`inline formatting tag "${tag}" is removed by the sanitizer if it has no attribute, kept otherwise`, () => {
+            const text = `<${tag}>no attribute</${tag}><${tag} id="myid">with id</${tag}>`;
+            modifyAndCheck(text, `no attribute<${tag} id="myid">with id</${tag}>`);
+        });
+    });
+
+    it('<br> tag variants are normalized to <br /> by the sanitizer', () => {
+        const text = '<p>text<br>with<br/>line<br />breaks</p>';
+        modifyAndCheck(text, '<p>text<br />with<br />line<br />breaks</p>');
+    });
+
+    // -------------------
+    // href links on <a> :
+    // -------------------
+
+    // The OWASP sanitizer encodes special characters in attribute values (e.g. @ -> &#64;, = -> &#61;)
+    const allowedHrefOnAWithEncoding = [
+        {input: 'mailto:johndoe@gmail.com', expected: 'mailto:johndoe&#64;gmail.com'},
+        {input: 'http://mywebsite.io/mypage.html?p1=v1&p2=v2', expected: 'http://mywebsite.io/mypage.html?p1&#61;v1&amp;p2&#61;v2'}
+    ];
+    allowedHrefOnAWithEncoding.forEach(link => {
+        it(`"${link.input}" is allowed as a[href] and its special characters are encoded by the sanitizer`, () => {
+            const text = `<a href="${link.input}">sample</a>`;
+            const expected = `<a href="${link.expected}">sample</a>`;
+            modifyAndCheck(text, expected);
+        });
+    });
+
+    // eslint-disable-next-line no-script-url
+    const disallowedHrefOnA = ['irc://sample.link', 'ftp://sample.link', 'ftps://sample.link', 'ssh://sample.link', 'javascript:alert("Hack!");'];
+    disallowedHrefOnA.forEach(link => {
+        it(`"${link}" is not allowed as a[href] - the entire <a> tag is removed by the sanitizer`, () => {
+            const text = `<a href="${link}">sample</a>`;
+            modifyAndCheck(text, 'sample'); // The whole <a> tag is removed
+        });
+    });
+
+    // -------
+    // media :
+    // -------
+
+    const mediaTextForLink = (link: string) => `
+    <audio controls="controls" muted="muted">
+      <source src="${link}" srcset="${link}" type="audio/ogg"/>
+    Your browser does not support the audio element.
+    </audio>
+
+    <img
+      src="${link}"
+      srcset="${link}"
+      alt="alt text" />
+
+    <video controls="controls" width="250" height="200" muted="muted">
+      <source src="${link}" type="video/webm" />
+    </video>
+
+    <video controls="controls" src="${link}">
+      <track
+        default="default"
+        kind="captions"
+        srclang="en"
+        src="${link}" />
+      Download the
+      <a href="${link}">MP4</a>
+      video, and
+      <a href="${link}">subtitles</a>.
+    </video>
+
+    <picture>
+      <source
+        srcset="${link}"
+        media="(orientation: portrait)" />
+      <img src="${link}" alt="alt text" />
+    </picture>
+    `;
+
+    // eslint-disable-next-line no-script-url
+    const disallowedMediaLinks = ['irc://sample.link', 'ftp://sample.link/audio.mp4', 'ftps://sample.link/sub/folder/logo.gif', 'ssh://sample.link', 'javascript:alert(\'hello\');'];
+    disallowedMediaLinks.forEach(link => {
+        it(`${link} is not an allowed media link - disallowed src/srcset attributes are removed by the sanitizer`, () => {
+            const text = mediaTextForLink(link);
+            const expectedText = `
+    <audio controls="controls" muted="muted">
+      <source type="audio/ogg"/>
+    Your browser does not support the audio element.
+    </audio>
+
+    <img
+      alt="alt text" />
+
+    <video controls="controls" width="250" height="200" muted="muted">
+      <source type="video/webm" />
+    </video>
+
+    <video controls="controls">
+      <track
+        default="default"
+        kind="captions"
+        srclang="en" />
+      Download the
+      MP4
+      video, and
+      subtitles.
+    </video>
+
+    <picture>
+      <source
+        media="(orientation: portrait)" />
+      <img alt="alt text" />
+    </picture>
+    `;
+            modifyAndCheck(text, expectedText);
+        });
+    });
+
+    // ----------------------
+    // <style> is protected :
+    // ----------------------
+
+    it('Style attribute: dangerous CSS properties are removed by the sanitizer while preserving safe styles', () => {
+        const text = `
+    <div style="color: blue; font-size: 14px; margin: 10px; border: 1px solid black;">Safe styling</div>
+
+    <div style="background-image: url('https://evil.com/tracking.jpg');">Remote image loading</div>
+    <div style="background: url('javascript:alert(1)');">JavaScript URL</div>
+    <div style="position: fixed; top: 0; left: 0; z-index: 9999;">Position manipulation</div>
+    <div style="-moz-binding: url('http://evil.com/xbl.xml#attack');">XBL binding</div>
+    <div style="behavior: url(malicious.htc);">IE behavior</div>
+    <div style="width: expression(alert('XSS'));">CSS expression</div>
+    <div style="background-image: url(data:image/svg+xml,%3Csvg%20onload%3Dalert(1)%3E%3C/svg%3E);">Data URL with SVG</div>
+    <div style="pointer-events: none;">Interaction hijacking</div>
+    `;
+
+        const expected = `
+    <div style="color:blue;font-size:14px;margin:10px;border:1px solid black">Safe styling</div>
+
+    <div>Remote image loading</div>
+    <div>JavaScript URL</div>
+    <div>Position manipulation</div>
+    <div>XBL binding</div>
+    <div>IE behavior</div>
+    <div>CSS expression</div>
+    <div>Data URL with SVG</div>
+    <div>Interaction hijacking</div>
+    `;
+
+        modifyAndCheck(text, expected);
+    });
+});
+

--- a/tests/cypress/e2e/graphql.cy.ts
+++ b/tests/cypress/e2e/graphql.cy.ts
@@ -1,5 +1,4 @@
-import {removeGlobalCustomConfig} from '../fixtures/utils';
-import {graphqlValidate} from '../fixtures/utils/graphql';
+import {graphqlValidate, removeGlobalCustomConfig} from '../fixtures/utils';
 
 describe('Test the GraphQL APIs endpoints', () => {
     const safeHTML = '<p>value</p>';

--- a/tests/cypress/e2e/publication.cy.ts
+++ b/tests/cypress/e2e/publication.cy.ts
@@ -59,11 +59,17 @@ describe('Test publications with HTML filtering module', () => {
         // Create a site with rich text component on the home page to store the HTML text to be filtered
         createSite(SITE_KEY, {locale: 'en', serverName: 'localhost', templateSet: 'html-filtering-test-module'});
         addContent('');
+
+        // Publish the node upfront so it already exists in LIVE before each test runs.
+        // Without this, the first test to run would publish the node for the first time, and the
+        // LIVE check would fail due to the async nature of the publication (the node may not exist
+        // in LIVE yet when the assertion runs).
+        publishContent();
     });
 
-    // EDIT workspace: SANITIZE everything, except [h1], LIVE: SANITIZE or REJECT everything, except [p]
+    // EDIT workspace: REJECT everything except [h1], LIVE: SANITIZE or REJECT everything, except [p]
     // Add content with tags that are allowed in EDIT workspace, but not in LIVE workspace (e.g. <h1>, <p>)
-    // (SANITIZED) content can be PUBLISHED in LIVE workspace, NO tags to be SANITIZED or REJECTED by LIVE config
+    // (Allowed) content can be PUBLISHED in LIVE workspace, NO tags to be SANITIZED or REJECTED by LIVE config
     ['SANITIZE', 'REJECT'].forEach(strategy => {
         it(`should publish content as is even if tags are restricted (${strategy}) in live config`, () => {
             cy.step('Install config', () => {

--- a/tests/cypress/fixtures/configs/globalDefaultConfiguration/org.jahia.modules.htmlfiltering.global.custom.yml
+++ b/tests/cypress/fixtures/configs/globalDefaultConfiguration/org.jahia.modules.htmlfiltering.global.custom.yml
@@ -1,40 +1,25 @@
-# global default configuration that is not meant to be updated.
-# To create a global configuration for multiple sites, use a configuration file named org.jahia.modules.htmlfiltering.global.custom.yml
-# To create a site-specific configuration, use a configuration file named org.jahia.modules.htmlfiltering.site-<site key>.yml
+# Global custom configuration that mirrors the global default rule set but uses SANITIZE strategy
+# for the edit workspace. Used by globalDefaultSanitizeStrategy.cy.ts to test the sanitization
+# behavior (output normalization, attribute/tag removal, etc.).
 htmlFiltering:
   formatDefinitions:
-    HTML_ID: '[a-zA-Z][a-zA-Z0-9\:\-_\.]*'  # IDs must start with a letter and can contain letters, digits, colons, hyphens, underscores, or dots
-    NUMBER_OR_PERCENT: '([0-9]+%?|[0-9]+\.[0-9]+%?|auto)' # Examples: "123", "123.45", "123.45%", "25%", "auto"
+    HTML_ID: '[a-zA-Z][a-zA-Z0-9\:\-_\.]*'
+    NUMBER_OR_PERCENT: '([0-9]+%?|[0-9]+\.[0-9]+%?|auto)'
     LINKS_URL: '(?:(?:[\p{L}\p{N}\\\.#@$%\+&;\-_~,\?=/!{}:]+|#(\w)+)|(\s*(?:(?:ht|f)tps?://|mailto:)[\p{L}\p{N}][\p{L}\p{N}\p{Zs}\.#@$%\+&:\-_~,\?=/!\(\)]*+\s*))'
   editWorkspace:
-    strategy: REJECT
+    strategy: SANITIZE
     skipOnPermissions: []
     process: [ 'nt:base.*' ]
     skip: [ ]
     allowedRuleSet:
-      # list of supported protocols. You may need to update LINKS_URL regex in case you add specific protocols
       protocols: [ http, https, mailto ]
       elements:
-        # allow all global attributes (see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes), except:
-        #   - the event handlers (onclick, etc.)
-        #   - the generic data-* that can potentially be misused by malicious JavaScript
-        #   - the experimental ones: anchor, virtualkeyboardpolicy, etc.)
-        #   - potentially risky ones: contenteditable, is,
-        #   - id that is restricted with a pattern
         - attributes: [ accesskey, autocapitalize, autocorrect, autofocus, class, dir, draggable, enterkeyhint, exportparts, hidden, inert, inputmode, lang, nonce, part, popover, slot, spellcheck, style, tabindex, title, translate, writingsuggestions ]
-
-        # allow id attribute on all tags but with format validation
         - attributes:
             - id
           format: HTML_ID
-
-        # inline formatting:
         - tags: [ b, big, br, code, del, em, font, i, ins, o, s, small, span, strike, strong, sub, sup, tt, u ]
-
-        # blocks:
         - tags: [ blockquote, div, h1, h2, h3, h4, h5, h6, li, ol, p, ul ]
-
-        # forms:
         - tags: [ form, fieldset, input, label, option, optgroup, select, textarea, datalist, output, progress, meter ]
         - attributes: [ accept, accept-charset, action, autocomplete, checked, dirname, enctype, for, formaction, formenctype, formmethod, formnovalidate, formtarget, list, max, maxlength, method, min, minlength, multiple, name, novalidate, pattern, placeholder, readonly, required, selected, size, step, value ]
           tags: [ form, input, button, select, textarea, option, optgroup, fieldset, label, datalist, output, progress, meter ]
@@ -44,9 +29,6 @@ htmlFiltering:
           tags: [ textarea ]
         - attributes: [ low, high, optimum ]
           tags: [ meter ]
-
-        # table-related tags and attributes
-        # table tags:
         - tags: [ caption, col, colgroup, table, tbody, td, tfoot, th, thead, tr ]
         - attributes: [ colspan, rowspan ]
           tags: [ td, th ]
@@ -57,13 +39,9 @@ htmlFiltering:
         - attributes: [ headers ]
           tags: [ td, th ]
         - attributes: [ height, width ]
-          tags: [  table, td, th, col, colgroup, video ]
+          tags: [ table, td, th, col, colgroup, video ]
           format: NUMBER_OR_PERCENT
-
-        # other common tags:
         - tags: [ a, abbr, address, article, aside, audio, button, canvas, cite, dd, details, dl, dt, figcaption, figure, footer, header, hgroup, hr, img, legend, main, mark, nav, picture, pre, q, section, source, summary, time, track, var, video, wbr ]
-
-        # common attributes on image and media tags
         - attributes: [ alt ]
           tags: [ img ]
         - attributes: [ src ]
@@ -82,15 +60,11 @@ htmlFiltering:
           tags: [ audio, img, source, video ]
         - attributes: [ default, kind, label, srclang ]
           tags: [ track ]
-
-        # Link attributes
         - attributes: [ href ]
           tags: [ a ]
           format: LINKS_URL
         - attributes: [ hreflang, media, rel, target, download ]
           tags: [ a ]
-
-        # Other useful element-specific attributes
         - attributes: [ cite ]
           tags: [ blockquote, del, ins, q ]
         - attributes: [ datetime ]
@@ -107,29 +81,14 @@ htmlFiltering:
     process: [ 'nt:base.*' ]
     skip: [ ]
     allowedRuleSet:
-      # list of supported protocols. You may need to update LINKS_URL regex in case you add specific protocols
       protocols: [ http, https, mailto ]
       elements:
-        # allow all global attributes (see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes), except:
-        #   - the event handlers (onclick, etc.)
-        #   - the generic data-* that can potentially be misused by malicious JavaScript
-        #   - the experimental ones: anchor, virtualkeyboardpolicy, etc.)
-        #   - potentially risky ones: contenteditable, is,
-        #   - id that is restricted with a pattern
         - attributes: [ accesskey, autocapitalize, autocorrect, autofocus, class, dir, draggable, enterkeyhint, exportparts, hidden, inert, inputmode, lang, nonce, part, popover, slot, spellcheck, style, tabindex, title, translate, writingsuggestions ]
-
-        # allow id attribute on all tags but with format validation
         - attributes:
             - id
           format: HTML_ID
-
-        # inline formatting:
         - tags: [ b, big, br, code, del, em, font, i, ins, o, s, small, span, strike, strong, sub, sup, tt, u ]
-
-        # blocks:
         - tags: [ blockquote, div, h1, h2, h3, h4, h5, h6, li, ol, p, ul ]
-
-        # forms:
         - tags: [ form, fieldset, input, label, option, optgroup, select, textarea, datalist, output, progress, meter ]
         - attributes: [ accept, accept-charset, action, autocomplete, checked, dirname, enctype, for, formaction, formenctype, formmethod, formnovalidate, formtarget, list, max, maxlength, method, min, minlength, multiple, name, novalidate, pattern, placeholder, readonly, required, selected, size, step, value ]
           tags: [ form, input, button, select, textarea, option, optgroup, fieldset, label, datalist, output, progress, meter ]
@@ -139,9 +98,6 @@ htmlFiltering:
           tags: [ textarea ]
         - attributes: [ low, high, optimum ]
           tags: [ meter ]
-
-        # table-related tags and attributes
-        # table tags:
         - tags: [ caption, col, colgroup, table, tbody, td, tfoot, th, thead, tr ]
         - attributes: [ colspan, rowspan ]
           tags: [ td, th ]
@@ -154,11 +110,7 @@ htmlFiltering:
         - attributes: [ height, width ]
           tags: [ table, td, th, col, colgroup, video ]
           format: NUMBER_OR_PERCENT
-
-        # other common tags:
         - tags: [ a, abbr, address, article, aside, audio, button, canvas, cite, dd, details, dl, dt, figcaption, figure, footer, header, hgroup, hr, img, legend, main, mark, nav, picture, pre, q, section, source, summary, time, track, var, video, wbr ]
-
-        # common attributes on image and media tags
         - attributes: [ alt ]
           tags: [ img ]
         - attributes: [ src ]
@@ -177,15 +129,11 @@ htmlFiltering:
           tags: [ audio, img, source, video ]
         - attributes: [ default, kind, label, srclang ]
           tags: [ track ]
-
-        # Link attributes
         - attributes: [ href ]
           tags: [ a ]
           format: LINKS_URL
         - attributes: [ hreflang, media, rel, target, download ]
           tags: [ a ]
-
-        # Other useful element-specific attributes
         - attributes: [ cite ]
           tags: [ blockquote, del, ins, q ]
         - attributes: [ datetime ]
@@ -196,3 +144,4 @@ htmlFiltering:
           tags: [ ol, ul, button ]
         - attributes: [ value ]
           tags: [ li ]
+

--- a/tests/cypress/fixtures/utils/assertion.ts
+++ b/tests/cypress/fixtures/utils/assertion.ts
@@ -1,0 +1,15 @@
+/**
+ * Asserts that the result of a mutation contains an HTML filtering validation error.
+ * @param result - Result of the Apollo mutation
+ * @param expectedMessage - Optional: specific message expected to be included in the error
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const expectHtmlValidationError = (result: any, expectedMessage?: string) => {
+    expect(result?.graphQLErrors).to.be.a('array');
+    expect(result?.graphQLErrors).to.have.length(1);
+    const error = result.graphQLErrors[0];
+    expect(error.errorType).to.eq('GqlConstraintViolationException');
+    if (expectedMessage) {
+        expect(error.message).to.include(expectedMessage);
+    }
+};

--- a/tests/cypress/fixtures/utils/index.ts
+++ b/tests/cypress/fixtures/utils/index.ts
@@ -1,2 +1,4 @@
+export * from './assertion';
 export * from './configuration';
+export * from './graphql';
 export * from './jcrNode';

--- a/tests/cypress/fixtures/utils/jcrNode.ts
+++ b/tests/cypress/fixtures/utils/jcrNode.ts
@@ -12,7 +12,7 @@ export const modifyContent = (pathOrId: string, text: string, language: string =
             }
         }
     `;
-    cy.apollo({
+    return cy.apollo({
         mutation: modifyNodeGql,
         variables: {pathOrId, text, language}
     });

--- a/tests/jahia-module/pom.xml
+++ b/tests/jahia-module/pom.xml
@@ -26,7 +26,7 @@
     <groupId>org.jahia.test</groupId>
     <artifactId>html-filtering-test-module</artifactId>
     <name>HTML filtering test module</name>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>A test module for HTML Filtering</description>
 


### PR DESCRIPTION
Closes https://github.com/Jahia/html-filtering/issues/168
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

**⚠️ https://github.com/Jahia/html-filtering/pull/171 should be merged first so the fix could be made available in both the 2.x and 3.x branches ⚠️** 

## Description

Changes the `editWorkspace.strategy` in the global default configuration (`org.jahia.modules.htmlfiltering.global.default.yml`) from `SANITIZE` to `REJECT`.

`REJECT` is already documented as the recommended strategy for the edit workspace. This change aligns the shipped default with that recommendation so that new installations are secure and explicit by default, without requiring any custom configuration.


## Behaviour change

### What REJECT means for content editors

When a content editor saves a rich text property containing HTML that does not comply with the allowed rule set (disallowed tags, attributes, or protocols), the save operation is **rejected with a validation error**. The editor is told exactly what is wrong and can correct it before saving.

Previously, with `SANITIZE`, invalid markup was **silently removed** and the cleaned-up version was stored, editors had no indication that their content had been modified.

### Content is stored exactly as entered

A critical difference of `REJECT` compared to `SANITIZE`: when validation passes, the module stores the **exact input** without any transformation. The sanitiser is run for validation purposes only and its output is never persisted. Concretely this means:

- **No HTML normalisation.** `<br>`, `<br/>`, and `<br />` remain as entered; the sanitiser's canonical `<br />` form is not imposed.
- **No character encoding.** Special characters in attribute values are left untouched (e.g. `mailto:user@example.com` is stored as-is, not as `mailto:user&#64;example.com`).

This makes content round-tripping fully predictable: what the editor types is what gets stored.

### Strategy comparison

|  | SANITIZE (previous default) | REJECT (new default) |
|---|---|---|
| Invalid HTML | Silently cleaned up; save succeeds | Save rejected with a validation error |
| Content stored | Sanitiser output (may differ from input) | Original input, unchanged |
| HTML normalisation (e.g. `<br>` → `<br />`) | Applied | Not applied |
| Character encoding (e.g. `@` → `&#64;` in URLs) | Applied | Not applied |
| Recommended workspace | Live | **Edit** ✓ |

> `SANITIZE` remains the default for the **live** workspace and is still the recommended strategy there, where content may be contributed by less privileged users and direct editor feedback is not always available.

---

## ⚠️ Breaking change

Sites relying on the **global default configuration** (i.e. without a site-specific or global custom configuration file) will observe the behaviour change described above. This is a breaking change.

**How to check if you are impacted:** If no `org.jahia.modules.htmlfiltering.global.custom.yml` or `org.jahia.modules.htmlfiltering.site-<SITE_KEY>.yml` file is deployed, the global default applies and you are affected.

**To restore the previous behaviour:** Create a `org.jahia.modules.htmlfiltering.global.custom.yml` (or a site-specific config) with `editWorkspace.strategy: SANITIZE`. The rest of the rule set can be identical to the global default.

**If keeping `REJECT`:** Content editors will receive validation errors when saving HTML that violates the rule set. Use the HTML Filtering GraphQL `validate` query to audit existing content before upgrading to identify anything that would have previously been silently cleaned up.
